### PR TITLE
line-height を日本語訳のみで広げる

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,14 +3,13 @@
 <head>
 <title>Authoring Tool Accessibility Guidelines (ATAG)  2.0 日本語訳</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<style type="text/css">
 
+<style type="text/css">
 body {
     color: #000000;
     font-weight: normal;
-    line-height: 1.3;
+    line-height: 1.5; /* only Japanese Translation */
 }
-
 h2.principle {
     background-color:#FFFFFF;
     border:thin solid #666666;
@@ -29,7 +28,7 @@ h4.sc-title {
     display: inline;
     margin-bottom: 0.5em;
     margin-top: 0.5em;
-	font: bold 0.9em sans-serif;
+    font: bold 0.9em sans-serif;
 }
 p.sc-title {
     display: inline;
@@ -39,18 +38,18 @@ ul.sc-bullets {
     padding-left:2em;
     margin-top: 0em;
     margin-bottom: 0em;
-	list-style-type: none;
+    list-style-type: none;
 }
 ul.sc-notes {
     display:block;
     padding-left:1em;
     margin-top: 0em;
     margin-bottom: 0em;
-	list-style-type: none;
+    list-style-type: none;
 }
 h5.implementing-heading {
     font-size:0.9em;
-	font-weight:bold;
+    font-weight:bold;
     font-style:normal;
     margin-top: 0em;
     margin-bottom: 0.5em;
@@ -61,35 +60,35 @@ span.level {
 }
 div.implementing-link {
     font-size: 0.9em;
-	margin-top: 0.5em;
-	margin-left: 0.5em;
-	margin-bottom: 1em;
+    margin-top: 0.5em;
+    margin-left: 0.5em;
+    margin-bottom: 1em;
 }
 div.implementing-link a{
     background-color: #F4F4FF;
     border-color:#BBBBBB;
     border-style: solid;
     border-width: 1px;
-	padding: 0.25em;
+    padding: 0.25em;
 }
 div.implementing-section {
     border: #DDDDDD 1px solid;
-	margin-left: 0.5em;
+    margin-left: 0.5em;
     margin-top: 0.5em;
-	padding:0.5em;
+    padding:0.5em;
 }
 div.implementing-section p {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
 }
 p.rationale {
-	margin-left: 1em;
+    margin-left: 1em;
 }
 ul.techs-only {
     border: gray 1px solid;
-	padding: 0.5em;
-	margin: 0.1em;
-	list-style:none;
+    padding: 0.5em;
+    margin: 0.1em;
+    list-style:none;
 }
 strong.handle {
     font-size: .9em;
@@ -98,8 +97,8 @@ em.note-handle {
     font-size: .9em;
 }
 dfn {
-	font-weight:bold;
-	font-style:normal;
+    font-weight:bold;
+    font-style:normal;
 }
 .figure {
     font-size:x-small;
@@ -112,20 +111,20 @@ DL {
     color:#000000 !important;
     text-decoration:none;
 }
-dt {margin-top: 0.5em}
-
+dt {
+    margin-top: 0.5em
+}
 div.toc ul.toc li a {
-     margin-top:.3em;
+    margin-top:.3em;
 }
 div.toc ul.toc li ul.toc li a {
-     margin-top:.3em;
+    margin-top:.3em;
 }
 div.toc ul.toc li ul.toc li ul.toc li a {
-     margin-top:0;
+    margin-top:0;
 }
-
-
 </style>
+
 <link href="https://www.w3.org/StyleSheets/TR/W3C-REC.css" type="text/css" rel="stylesheet" />
 
 </head>


### PR DESCRIPTION
### 概要

原文では問題ないが、日本語になると行間が狭いので読みにくいため本文などの行間を広げる。

=> WG4 の 2018/02/22 定例ミーティングにて決定

### 実装

- `line-height: 1.5`
- その他CSSのインデントなどを調整…

`1.5` の根拠は [WCAG 2.0 1.4.8 Visual Presentation の 4](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation) より

> Line spacing (leading) is at least space-and-a-half within paragraphs, and paragraph spacing is at least 1.5 times larger than the line spacing.

