### PR TITLE
Issue #45 対応

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -431,9 +431,9 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <div class="sc-level">
 
       <h4 class="sc-title"><a id="sc_a121" name="sc_a121"></a>A.1.2.1 アクセシビリティガイドライン: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>に<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベースのユーザインタフェース</a>が含まれている場合、その非ウェブベースのユーザインタフェースは使用している<a class="termdef" href="#def-Platform" title="定義: プラットフォーム">プラットフォーム</a>のユーザインタフェースアクセシビリティガイドラインに従う。<span class="level">（<strong>レベル A</strong>）</span></p>
+      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>に<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベースのユーザインタフェース</a>が含まれている場合、その非ウェブベースのユーザインタフェースは使用している<a class="termdef" href="#def-Platform" title="定義: プラットフォーム">プラットフォーム</a>のユーザインタフェース アクセシビリティガイドラインに従う。<span class="level">（<strong>レベル A</strong>）</span></p>
 	  <ul class="sc-notes">
-    <li class="sc-note"><em class="note-handle">注記: </em>（任意の）<a href="#conf-explanation-results">適合表明の結果の説明</a>には、ユーザインタフェースアクセシビリティガイドラインに従ったことを記録するべきである。</li>
+    <li class="sc-note"><em class="note-handle">注記: </em>（任意の）<a href="#conf-explanation-results">適合表明の結果の説明</a>には、ユーザインタフェース アクセシビリティガイドラインに従ったことを記録するべきである。</li>
 	</ul>
 
 	   <div class="gl-only">
@@ -541,7 +541,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
       <h4 class="sc-title"><a id="sc_a312" name="sc_a312"></a>A.3.1.2 キーボードトラップなし: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース">キーボードインタフェース</a>を用いてキーボードフォーカスを<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">コンポーネント</a>に移動できる場合、キーボードインタフェースだけを用いてそのコンポーネントからフォーカスを移動することができる。さらに、修飾キーを伴わない矢印キー、 Tab キー、またはフォーカスを外すその他の標準的な方法でフォーカスを外せない場合は、フォーカスを外す方法が<span class="sc-bullet"><a class="termdef" href="#def-Author" title="定義: 著者">著者</a></span>に提供される。<span class="level">（<strong>レベル A</strong>）</span></p>
+      <p class="sc-title"><a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース">キーボードインタフェース</a>を用いてキーボードフォーカスを<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">コンポーネント</a>に移動できる場合、キーボードインタフェースだけを用いてそのコンポーネントからフォーカスを移動することができる。さらに、修飾キーを伴わない矢印キー、 Tab キー、またはフォーカスを外すその他の標準的な方法でフォーカスを外せない場合は、フォーカスを外す方法が<span class="sc-bullet"><a class="termdef" href="#def-Author" title="定義: 著者">著者</a></span>に提供される。<span class="level">（<strong>レベル A</strong>）</span></p>
       <div class="gl-only">
         <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a312">A.3.1.2 を実装する</a></div>
 	   </div>
@@ -621,7 +621,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
       <h4 class="sc-title"><a id="sc_a323" name="sc_a323"> </a>A.3.2.3 静的な入力コンポーネント: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>オーサリングツールには、<a class="termdef" href="#def-Author" title="定義: 著者">著者</a>が動きを停止することができない動きのある<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">ユーザインタフェースコンポーネント</a>が含まれていない。<span class="level">（<strong>レベル A</strong>）</span></p>
+      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>オーサリングツールには、<a class="termdef" href="#def-Author" title="定義: 著者">著者</a>が動きを停止することができない動きのある<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">ユーザインタフェース コンポーネント</a>が含まれていない。<span class="level">（<strong>レベル A</strong>）</span></p>
       <div class="gl-only">
         <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a323">A.3.2.3 を実装する</a></div>
       </div>
@@ -1686,7 +1686,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <dd>キーボードインタフェースは多くのプラットフォームで提供されている、デバイスに依存しない方法で操作を可能にするプログラム型のサービスである。キーボードインタフェースは特定のデバイスがハードウェアキーボードを持っていなくてもキーストローク入力を可能にする。(例えば、タッチスクリーンで制御するデバイスは、外部接続されたキーボードに対応するのと同様に、スクリーン上のキーボードに対応するためのオペレーティングシステムに組み込まれたキーボードインタフェースを持つことができる。)<br />
     <em> 注記:</em> マウスキーのようなキーボードで操作するマウスエミュレーターはキーボードインタフェースからの操作とはみなさない。なぜならこれらのエミュレーターはキーボードインタフェースではなくポインティングデバイスインタフェースを利用するからである。</dd>
     <dt><dfn><a name="def-Keyboard-Trap" id="def-Keyboard-Trap"></a>キーボードトラップ (keyboard trap)</dfn></dt>
-    <dd><a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース">キーボードインタフェース</a>が<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">ユーザインタフェースコンポーネント</a>、又はコンポーネントのグループにフォーカスを移動することができるが、そこからフォーカスを移動することができないユーザインタフェースの状態。</dd>
+    <dd><a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース">キーボードインタフェース</a>が<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">ユーザインタフェース コンポーネント</a>、又はコンポーネントのグループにフォーカスを移動することができるが、そこからフォーカスを移動することができないユーザインタフェースの状態。</dd>
 
     <dt><dfn><a id="def-Label" name="def-Label"></a>ラベル (label)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
     <dd>テキスト、又はテキストによる代替を伴う<a class="termdef" href="#def-UI-Component" title="定義: コンポーネント">コンポーネント</a>で、コンポーネントを識別するために利用者に提示されているもの。<a href="#def-Name" title="定義: 名前 (name)" class="termdef">名前 (name)</a> は隠されていて<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>に対してだけ明らかにされる場合がある一方で、ラベルはすべての利用者に提示される。多くの場合 (すべてではないが)、名前 (name) とラベルは同じである。</dd>
@@ -1700,7 +1700,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <ul><li><a name="def-Markup" id="def-Markup"></a>コンテンツの<dfn>マークアップ</dfn>はコンテンツに表示される注釈のセットである。</li></ul></dd>
 
     <dt><a name="def-Name" id="def-Name"></a><dfn>名前 (name)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd>ソフトウェアによる<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">ユーザインタフェースコンポーネント</a>を<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>、又は<a href="#def-End-Users" title="定義: エンドユーザに" class="termdef">エンドユーザに</a>識別させることができるテキスト。<a title="定義: ラベル" class="termdef" href="#def-Label">ラベル</a>はすべての利用者に表示されるが、名前 (name) は隠され、<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>に対してだけ明らかにされる場合もある。多くの場合 (すべてではないが)、ラベルと名前 (name) は同じである。</dd>
+    <dd>ソフトウェアによる<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">ユーザインタフェース コンポーネント</a>を<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>、又は<a href="#def-End-Users" title="定義: エンドユーザに" class="termdef">エンドユーザに</a>識別させることができるテキスト。<a title="定義: ラベル" class="termdef" href="#def-Label">ラベル</a>はすべての利用者に表示されるが、名前 (name) は隠され、<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>に対してだけ明らかにされる場合もある。多くの場合 (すべてではないが)、ラベルと名前 (name) は同じである。</dd>
 
     <dt><dfn><a id="def-Non-Text-Objects" name="def-Non-Text-Objects"></a>非テキストコンテンツ (non-text content)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
     <dd><a class="termdef" href="#def-Programmatically-Determined" title="定義: プログラムによる解釈">プログラムによる解釈</a>が可能な文字の並びではない<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ">コンテンツ</a>、又は文字の並びが<a title="定義: 自然言語" class="termdef" href="#def-Human-Language">自然言語</a>において何をも表現していないコンテンツ。これにはASCIIアート (文字による図画)、顔文字や文字を表現している画像が含まれる。</dd>
@@ -1726,7 +1726,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <dd><a href="#def-Authoring-Tool" title="定義: オーサリングツール" class="termdef">オーサリングツール</a>の一部として実行されるプログラム (例えば、サードパーティのチェックツールや<a href="#def-Repairing" title="定義: 修復" class="termdef">修復</a>ツールなど) で、<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のウェブコンテンツ">編集中のウェブコンテンツ</a>は含まれない。<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>は通常オーサリングツールからプラグインを組み込むか除外するかを選択する。</dd>
 
     <dt><a id="def-Preauthored-Content" name="def-Preauthored-Content"><dfn>オーサリング済みコンテンツ (pre-authored content)</dfn></a></dt>
-    <dd>オーサリングツール<a href="#def-Developer" title="定義: 開発者" class="termdef">開発者</a>が用意した<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ">編集中のコンテンツ</a>の中で利用できる<a href="#def-Authoring-Session" title="定義: オーサリングセッション" class="termdef">オーサリングセッション</a>より前に作成された<a href="#def-Web-Content" title="定義: ウェブコンテンツ" class="termdef">ウェブコンテンツ</a>の一部。例えば、クリップアートやサンプル動画、ユーザインタフェースウィジェットが含まれる。<br />
+    <dd>オーサリングツール<a href="#def-Developer" title="定義: 開発者" class="termdef">開発者</a>が用意した<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ">編集中のコンテンツ</a>の中で利用できる<a href="#def-Authoring-Session" title="定義: オーサリングセッション" class="termdef">オーサリングセッション</a>より前に作成された<a href="#def-Web-Content" title="定義: ウェブコンテンツ" class="termdef">ウェブコンテンツ</a>の一部。例えば、クリップアートやサンプル動画、ユーザインタフェース ウィジェットが含まれる。<br />
     <em >注記 1:</em> <a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>は不完全なオーサリング済みコンテンツ。<a href="#gl_b24">ガイドライン B.2.4</a>を参照のこと。<br />
     <em >注記 2:</em> オーサリングツールが自動的にオーサリング済みコンテンツを利用する場合に関しては、<a href="#gl_b11">ガイドライン B.1.1</a>を参照のこと。
       <ul>
@@ -1752,9 +1752,9 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       </ul>
     </dd>
     <dt><dfn><a id="def-Prominence" name="def-Prominence"></a>目立つ度合い (prominence)</dfn></dt>
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>がユーザインタフェースの操作中に、ある<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">ユーザインタフェースコンポーネント</a>に気づく可能性がどの程度あるかという発見的な尺度。目立つ度合いは様々な要因によって影響を受ける: 例えば、必要なナビゲーションステップの数、読み上げ順序の位置、視覚的特性 (大きさ、間隔、色)、さらに使用方法 (マウスまたキーボード) など。
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>がユーザインタフェースの操作中に、ある<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">ユーザインタフェース コンポーネント</a>に気づく可能性がどの程度あるかという発見的な尺度。目立つ度合いは様々な要因によって影響を受ける: 例えば、必要なナビゲーションステップの数、読み上げ順序の位置、視覚的特性 (大きさ、間隔、色)、さらに使用方法 (マウスまたキーボード) など。
       <ul>
-        <li><dfn><a name="def-At-Least-As-Prominent" id="def-At-Least-As-Prominent"></a>少なくとも同程度目立つ:</dfn> ATAG 2.0では次の場合に、<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェースコンポーネント">ユーザインタフェースコンポーネント</a>Aが他のコンポーネントBよりも「少なくとも同程度目立つ」と考える。既定の状態からコンポーネントBが表示 (かつ有効) となる場合よりも同じかより少ない「オープニングアクション (Opening actions)」とともに、コンポーネントAが表示 (かつ有効) となった場合。<br />
+        <li><dfn><a name="def-At-Least-As-Prominent" id="def-At-Least-As-Prominent"></a>少なくとも同程度目立つ:</dfn> ATAG 2.0では次の場合に、<a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース コンポーネント">ユーザインタフェース コンポーネント</a>Aが他のコンポーネントBよりも「少なくとも同程度目立つ」と考える。既定の状態からコンポーネントBが表示 (かつ有効) となる場合よりも同じかより少ない「オープニングアクション (Opening actions)」とともに、コンポーネントAが表示 (かつ有効) となった場合。<br />
         <em> 注記 1:</em> コンテナが開いている場合は、コンテナ内の有効なコンポーネント (リスト内のアイテム、メニュー内のアイテム、ツールバーのボタン、ダイアログボックス内のすべてのコンポーネント) はすべて表示されているとみなされる (したがって「少なくとも同程度目立つ」)。コンテナーをスクロールして表示可能にしなければならない場合も同様で、これは様々なスクリーンの大きさと<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>の設定が一定期間表示されるコンポーネントに影響することを考慮している。<br />
         <em> 注記 2:</em> 「オープニングアクション (Opening actions)」は、新しいコンポーネントを表示、又は有効とするために、コンテンツ制作者がユーザインタフェースの中のコンポーネントに対して起こすアクションである。
         例 : (a) サブメニューを表示するためのトップレベルメニューアイテムのキーボードショートカット、(b) ダイアログボックスを表示するためのボタンをキーボードで選択する、(c) 無効だったサブアイテムを有効にするためにチェックボックスをマウスでクリックするなど。新しいコンポーネントをアクション可能にしないアクション (フォーカスを移動する、リストをスクロールする)、は「オープニングアクション (opening actions)」としてカウントしない。<br />

--- a/docs/index.html
+++ b/docs/index.html
@@ -329,7 +329,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <li>すべてのコンテンツ制作者が、使用するオーサリングツールによって、<a class="termdef" href="#def-Accessible-Web-Content" title="定義: アクセシブルなウェブコンテンツ">アクセシブルなウェブコンテンツ（WCAG）</a>の制作を実現でき、サポートされ、ガイドされること（<a href="#part_b">ガイドラインのパートB</a>を参照）で、ニーズが満たされるウェブコンテンツの<a class="termdef" href="#def-End-Users" title="定義: エンドユーザ">エンドユーザ</a></li>
 
     </ul>
-  <p>この2つの利用者のニーズを満たすための要件は、ガイドライン内で分かりやすくするために分離されているが、利用者作成コンテンツの流行において、実際には相互に深く関連していることに注意すべきである。例えば、利用者がオンラインフォーラムに参加する場合、利用者はしばしばコンテンツを作成し、他の利用者によって作成されたコンテンツと組み合わされる。オーサリングユーザインタフェース、または他のフォーラム利用者によって作成されたコンテンツのアクセシビリティの問題は、フォーラムの全体的なアクセシビリティを低下させる。</p>
+  <p>この2つの利用者のニーズを満たすための要件は、ガイドライン内で分かりやすくするために分離されているが、利用者作成コンテンツの流行において、実際には相互に深く関連していることに注意すべきである。例えば、利用者がオンラインフォーラムに参加する場合、利用者はしばしばコンテンツを作成し、他の利用者によって作成されたコンテンツと組み合わされる。オーサリング ユーザインタフェース、または他のフォーラム利用者によって作成されたコンテンツのアクセシビリティの問題は、フォーラムの全体的なアクセシビリティを低下させる。</p>
   <h4><a id="intro-notes" name="intro-notes"></a>注記:</h4>
   <ol>
     <li>「<a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>」という用語は ATAG 2.0 において特定の定義がある。いくつかの<a class="termdef" href="#def-Normative" title="定義: 規定">規定</a>の注釈を含む定義は、<a href="#glossary">用語集</a>に記載されている。</li>
@@ -1715,7 +1715,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     </ul></dd>
 
     <dt><dfn><a name="def-Platform" id="def-Platform"></a>プラットフォーム (platform)</dfn></dt>
-    <dd><a href="#def-Authoring-Tool" title="定義: オーサリングツールが" class="termdef">オーサリングツールが</a>動作するソフトウェアの環境。プラットフォームは低レベルのソフトウェアプラットフォーム、又はハードウェア上で一貫した動作環境を提供する。<a href="#def-Web-Based-UI" title="定義: ウェブベースのオーサリングユーザインタフェース" class="termdef">ウェブベースのオーサリングユーザインタフェース</a>の場合、最も関連するプラットフォームは<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a> (ブラウザなど) となる。<a href="#def-Non-Web-Based" title="定義: 非ウェブベースのユーザインタフェース" class="termdef">非ウェブベースのユーザインタフェース</a>の場合、デスクトップのオペレーティングシステム (GNOME desktop on Linux、Mac OS、Windowsなど)、モバイルオペレーティングシステム (Android、BlackBerry、iOS、Windows Phoneなど)、又はOSをまたいだ環境 (Javaなど) などが含まれるが、これらに限らない。<br />
+    <dd><a href="#def-Authoring-Tool" title="定義: オーサリングツールが" class="termdef">オーサリングツールが</a>動作するソフトウェアの環境。プラットフォームは低レベルのソフトウェアプラットフォーム、又はハードウェア上で一貫した動作環境を提供する。<a href="#def-Web-Based-UI" title="定義: ウェブベースのオーサリング ユーザインタフェース" class="termdef">ウェブベースのオーサリング ユーザインタフェース</a>の場合、最も関連するプラットフォームは<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a> (ブラウザなど) となる。<a href="#def-Non-Web-Based" title="定義: 非ウェブベースのユーザインタフェース" class="termdef">非ウェブベースのユーザインタフェース</a>の場合、デスクトップのオペレーティングシステム (GNOME desktop on Linux、Mac OS、Windowsなど)、モバイルオペレーティングシステム (Android、BlackBerry、iOS、Windows Phoneなど)、又はOSをまたいだ環境 (Javaなど) などが含まれるが、これらに限らない。<br />
       <em> 注記 1:</em> 多くのプラットフォームはプラットフォーム上で動作するアプリケーションと支援技術の間を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォームアクセシビリティサービス">プラットフォームアクセシビリティサービス</a>を介して仲介する。<br />
     <em> 注記 2:</em> <a href="#def-Developer" title="定義: 開発者" class="termdef">開発者</a>のためのアクセシビリティに関するガイドラインは多くのプラットフォームで存在する。</dd>
 


### PR DESCRIPTION
「ユーザインタフェース」に連続してカタカナ語句が続く場合、読みにくくなるため、半角スペースを入れました。具体的には、以下の3つです。

- ユーザインタフェース アクセシビリティガイドライン
- ユーザインタフェース コンポーネント
- ユーザインタフェース ウィジェット