### PR TITLE
close #42 タイトルから「日本語訳」を削除

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="ja" xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja">
 <head>
-<title>Authoring Tool Accessibility Guidelines (ATAG)  2.0 日本語訳</title>
+<title>Authoring Tool Accessibility Guidelines (ATAG)  2.0</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
 <style type="text/css">
@@ -139,7 +139,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <p align="center">[<a href="#contents">Table of Contents</a>] &nbsp;|&nbsp; [<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/">Implementing ATAG 2.0</a>]
 </p>
 <a href="http://www.w3.org/"><img height="48" src="https://www.w3.org/Icons/w3c_home" width="72" alt="W3C"/></a>
-  <h1><a name="title" id="title"></a>Authoring Tool Accessibility Guidelines (ATAG) 2.0 日本語訳</h1>
+  <h1><a name="title" id="title"></a>Authoring Tool Accessibility Guidelines (ATAG) 2.0</h1>
   <h2><a name="w3c-doctype" id="w3c-doctype"></a>W3C 勧告 2015年9月24日</h2>
   <dl>
     <dt>このバージョン:</dt>


### PR DESCRIPTION
#42 の対応として、title要素およびh1見出しから「日本語訳」を削除しました。