### PR TITLE
「プラットフォーム アクセシビリティサービス」に統一 #90

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -426,7 +426,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 </h3>
 
-    <p class="rationale">根拠: <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>（またはオーサリングツールの一部）が<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベース</a>の場合、既存の<a href="#def-Platform" title="定義: プラットフォーム" class="termdef">プラットフォーム</a>のアクセシビリティガイドラインに従い、また<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォームアクセシビリティサービス</a>との通信を実装することにより、<a class="termdef" href="#def-Assistive-Technology" title="定義: 支援技術">支援技術</a>を使用する人を含む、すべての<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>によるアクセスが容易になる。</p>
+    <p class="rationale">根拠: <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>（またはオーサリングツールの一部）が<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベース</a>の場合、既存の<a href="#def-Platform" title="定義: プラットフォーム" class="termdef">プラットフォーム</a>のアクセシビリティガイドラインに従い、また<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォーム アクセシビリティサービス</a>との通信を実装することにより、<a class="termdef" href="#def-Assistive-Technology" title="定義: 支援技術">支援技術</a>を使用する人を含む、すべての<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>によるアクセスが容易になる。</p>
 
     <div class="sc-level">
 
@@ -443,10 +443,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
        <!-- techs-only -->
 
-      <h4 class="sc-title"><a id="sc_a122" name="sc_a122"></a>A.1.2.2 プラットフォームアクセシビリティサービス: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>に<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベースのユーザインタフェース</a>が含まれている場合、その非ウェブベースのユーザインタフェースは使用している<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォームアクセシビリティサービス</a>を通じてアクセシビリティ情報を公開する。<span class="level">（<strong>レベル A</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a122" name="sc_a122"></a>A.1.2.2 プラットフォーム アクセシビリティサービス: </h4>
+      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>に<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース（非ウェブベース）">非ウェブベースのユーザインタフェース</a>が含まれている場合、その非ウェブベースのユーザインタフェースは使用している<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォーム アクセシビリティサービス</a>を通じてアクセシビリティ情報を公開する。<span class="level">（<strong>レベル A</strong>）</span></p>
          <ul class="sc-notes">
-    <li class="sc-note"><em class="note-handle">注記: </em><em class="note-handle"></em>任意の<a href="#conf-explanation-results">適合表明の結果の説明</a>には、実装されたプラットフォームアクセシビリティサービスを記録するべきである。</li>
+    <li class="sc-note"><em class="note-handle">注記: </em><em class="note-handle"></em>任意の<a href="#conf-explanation-results">適合表明の結果の説明</a>には、実装されたプラットフォーム アクセシビリティサービスを記録するべきである。</li>
       </ul>
 	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a122">Implementing A.1.2.2</a></div>
@@ -829,7 +829,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       <li class="sc-bullet"><strong class="handle">(a) ドキュメントで説明:</strong> 機能の使用方法はオーサリングツールの<a class="termdef" href="#def-Documentation" title="定義: ドキュメンテーション">ドキュメンテーション</a>に記載されている。または、</li>
       <li class="sc-bullet"><strong class="handle">(b) インタフェース上で説明:</strong> 機能の使用方法は<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース" class="termdef">オーサリングツールのユーザインタフェース</a>上に記載されている。または、</li>
       <li class="sc-bullet"><strong class="handle">(c) プラットフォームサービス:</strong> 機能は基盤となるプラットフォームによって提供されている。または、</li>
-      <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>が直接使用しない ( 例えば情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォームアクセシビリティサービス</a>に渡すなど ) 。</li>
+      <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="定義: コンテンツ制作者" class="termdef">コンテンツ制作者</a>が直接使用しない ( 例えば情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: アクセシビリティプラットフォームアーキテクチャ">プラットフォーム アクセシビリティサービス</a>に渡すなど ) 。</li>
 	  </ul>
 	  <ul class="sc-notes">
 <li class="sc-note"><em class="note-handle">注記:</em> ドキュメンテーションのアクセシビリティについては<a href="#gl_a11">ガイドライン A.1.1</a>および<a href="#gl_a11">ガイドライン A.1.2</a>を参照。</li></ul>
@@ -848,7 +848,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
         <li class="sc-bullet"><strong class="handle">(a) ドキュメントで説明:</strong> 機能の使用方法はオーサリングツールの<a class="termdef" href="#def-Documentation" title="definition: documentation">ドキュメンテーション</a>に記載されている。又は、</li>
         <li class="sc-bullet"><strong class="handle">(b) インタフェース上で説明:</strong> 機能の使用方法は<a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">オーサリングツールのユーザインタフェース</a>上に記載されている。又は、</li>
         <li class="sc-bullet"><strong class="handle">(c) プラットフォームサービス:</strong> 機能は基盤となるプラットフォームによって提供されている。又は、</li>
-        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォームアクセシビリティサービス</a>に渡す).</li>
+        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォーム アクセシビリティサービス</a>に渡す).</li>
       </ul>
       <ul class="sc-notes">
       <li class="sc-note"><em class="note-handle">注記:</em> ドキュメンテーションのアクセシビリティについては<a href="#gl_a11">ガイドライン A.1.1</a>及び<a href="#gl_a11">ガイドライン A.1.2</a>を参照。</li></ul>
@@ -1403,7 +1403,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
   <p> <em>注記 1:</em> 追加のオーサリングプロセスコンポーネントが (例えば、セキュリティ上の理由のため) 失敗した達成基準を満たさないように防ぐ場合、オーサリングツールは部分適合を満たすことができないだろう。<br />
     <em>注記 2:</em> <a href="#part_a_applic_notes">パート A の適合適用性に関する注記</a>及び<a href="#part_b_applic_notes">パート B の適合適用性に関する注記</a>が適用されなければならない。 </p>
   <h5><a name="conf-partial-platform-limits" id="conf-partial-platform-limits"></a>ATAG 2.0 部分適合 - プラットフォームの制限（レベルA、AA、またはAAA）</h5>
-  <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が (例えば、<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォームのアクセシビリティサービス</a>を欠いているなど) <a class="termdef" href="#def-Platform" title="definition: platform">プラットフォーム</a>固有の制限のために一つ以上の達成基準を満たすことができない場合、この適合オプションが選択されてもよい。(任意の) 適合表明の結果の説明は、どのプラットフォームの機能が欠けているかを説明することが望ましい。 </p>
+  <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が (例えば、<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォーム アクセシビリティサービス</a>を欠いているなど) <a class="termdef" href="#def-Platform" title="definition: platform">プラットフォーム</a>固有の制限のために一つ以上の達成基準を満たすことができない場合、この適合オプションが選択されてもよい。(任意の) 適合表明の結果の説明は、どのプラットフォームの機能が欠けているかを説明することが望ましい。 </p>
 
   <h4><a name="conf-techs-produced" id="conf-techs-produced"> </a>ウェブコンテンツ技術の制作:</h4>
   <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、特定の<a class="termdef" href="#def-Web-Content-Technology" title="definition: technology (Web content)">ウェブコンテンツ技術</a>の制作物に関して ATAG 2.0 に適合する (例えば、XHTML 1.0 の制作物に関して、レベル A 適合)。</p>
@@ -1430,7 +1430,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       <ul>
         <li><a name="conf-user-agents" id="conf-user-agents"></a>(<a class="termdef" href="#def-Web-Based-UI" title="definition: authoring tool user interface (Web-based)">ウェブベースのオーサリングツール</a>のユーザインタフェースを評価するために使用される) <strong><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>プラットフォーム</strong>の場合: ユーザエージェントの名前及びバージョン情報を提供する。</li>
 
-        <li> <a name="conf-not-user-agents" id="conf-not-user-agents"></a>(<a class="termdef" href="#def-Non-Web-Based" title="definition: authoring tool user interface (non-Web-Based)">非ウェブベースのオーサリングツールのユーザインタフェース</a>を評価するために使用される) <strong><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>ではないプラットフォーム</strong>の場合: プラットフォーム (例えばデスクトップオペレーティングシステム、モバイルオペレーティングシステム、クロス OS 環境) の名前及びバージョン情報並びに採用された<a href="#def-Accessibility-Platform-Service" title="definition: platform accessibility architectur" class="termdef">プラットフォームアクセシビリティサービス</a>の名前及びバージョンを提供する。</li>
+        <li> <a name="conf-not-user-agents" id="conf-not-user-agents"></a>(<a class="termdef" href="#def-Non-Web-Based" title="definition: authoring tool user interface (non-Web-Based)">非ウェブベースのオーサリングツールのユーザインタフェース</a>を評価するために使用される) <strong><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>ではないプラットフォーム</strong>の場合: プラットフォーム (例えばデスクトップオペレーティングシステム、モバイルオペレーティングシステム、クロス OS 環境) の名前及びバージョン情報並びに採用された<a href="#def-Accessibility-Platform-Service" title="definition: platform accessibility architectur" class="termdef">プラットフォーム アクセシビリティサービス</a>の名前及びバージョンを提供する。</li>
       </ul>
     </li>
     <li><strong>表明に含まれているオーサリングツールによって生成されたウェブコンテンツ技術</strong>のリスト。適合表明に含まれていないオーサリングツールによって<a href="#conf-techs-produced">生成される</a>任意の<a class="termdef" href="#def-Web-Content-Technology" title="definition: technology (Web content)">ウェブコンテンツ技術</a>が存在する場合、個別に列挙されなければならない。オーサリングツールがデフォルトで任意のウェブコンテンツ技術を生成する場合、これは含まれていなければならない。</li>
@@ -1669,7 +1669,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <dd><a href="#def-Authoring-Tool" title="定義: オーサリングツール" class="termdef">オーサリングツール</a>の使用を支援するための情報。この情報は、電子的又は他の方法で提供されてもよい。また、この情報にはヘルプ、マニュアル、インストール手順、サンプル<a class="termdef" href="#def-Workflow" title="定義: ワークフロー">ワークフロー</a>、<a href="#def-Tutorial" title="定義: チュートリアル" class="termdef">チュートリアル</a>などが含まれる。</dd>
 
     <dt><a id="def-Document-Object" name="def-Document-Object"></a><dfn>ドキュメントオブジェクト (document object)</dfn></dt>
-    <dd><a href="#def-Non-Web-Based" title="定義: 非ウェブベースのオーサリングツール" class="termdef">非ウェブベースのオーサリングツール</a>又は<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>による<a class="termdef" title="定義: ソース" href="#def-Instruction-Level">ソース</a>内のデータの内部表現。ドキュメントオブジェクトは<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>とのやりとりを可能にする<a href="#def-Accessibility-Platform-Service" title="定義: プラットフォームのアクセシビリティサービス" class="termdef">プラットフォームのアクセシビリティサービス</a>の一部を形成する。 <a href="#def-Web-Based-UI" title="定義: ウェブベースのオーサリングツール" class="termdef">ウェブベースのオーサリングツール</a>は<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>が管理するドキュメントオブジェクトを利用してもよい。</dd>
+    <dd><a href="#def-Non-Web-Based" title="定義: 非ウェブベースのオーサリングツール" class="termdef">非ウェブベースのオーサリングツール</a>又は<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>による<a class="termdef" title="定義: ソース" href="#def-Instruction-Level">ソース</a>内のデータの内部表現。ドキュメントオブジェクトは<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>とのやりとりを可能にする<a href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス" class="termdef">プラットフォーム アクセシビリティサービス</a>の一部を形成する。 <a href="#def-Web-Based-UI" title="定義: ウェブベースのオーサリングツール" class="termdef">ウェブベースのオーサリングツール</a>は<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>が管理するドキュメントオブジェクトを利用してもよい。</dd>
 
     <dt><a id="def-Element" name="def-Element"><dfn>要素 (element)</dfn></a></dt>
     <dd><a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>タグとその内容のペア、又は「空タグ」
@@ -1717,10 +1717,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     <dt><dfn><a name="def-Platform" id="def-Platform"></a>プラットフォーム (platform)</dfn></dt>
     <dd><a href="#def-Authoring-Tool" title="定義: オーサリングツールが" class="termdef">オーサリングツールが</a>動作するソフトウェアの環境。プラットフォームは低レベルのソフトウェアプラットフォーム、又はハードウェア上で一貫した動作環境を提供する。<a href="#def-Web-Based-UI" title="定義: ウェブベースのオーサリング ユーザインタフェース" class="termdef">ウェブベースのオーサリング ユーザインタフェース</a>の場合、最も関連するプラットフォームは<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a> (ブラウザなど) となる。<a href="#def-Non-Web-Based" title="定義: 非ウェブベースのユーザインタフェース" class="termdef">非ウェブベースのユーザインタフェース</a>の場合、デスクトップのオペレーティングシステム (GNOME desktop on Linux、Mac OS、Windowsなど)、モバイルオペレーティングシステム (Android、BlackBerry、iOS、Windows Phoneなど)、又はOSをまたいだ環境 (Javaなど) などが含まれるが、これらに限らない。<br />
-      <em> 注記 1:</em> 多くのプラットフォームはプラットフォーム上で動作するアプリケーションと支援技術の間を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォームアクセシビリティサービス">プラットフォームアクセシビリティサービス</a>を介して仲介する。<br />
+      <em> 注記 1:</em> 多くのプラットフォームはプラットフォーム上で動作するアプリケーションと支援技術の間を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス">プラットフォーム アクセシビリティサービス</a>を介して仲介する。<br />
     <em> 注記 2:</em> <a href="#def-Developer" title="定義: 開発者" class="termdef">開発者</a>のためのアクセシビリティに関するガイドラインは多くのプラットフォームで存在する。</dd>
 
-    <dt><dfn><a id="def-Accessibility-Platform-Service" name="def-Accessibility-Platform-Service"></a>プラットフォームアクセシビリティサービス (platform accessibility service)</dfn></dt>
+    <dt><dfn><a id="def-Accessibility-Platform-Service" name="def-Accessibility-Platform-Service"></a>プラットフォーム アクセシビリティサービス (platform accessibility service)</dfn></dt>
     <dd>アプリケーションと<a href="#def-Assistive-Technology" title="定義: 支援技術" class="termdef">支援技術</a>間のやりとりを提供するため特別に設計されたプログラムによるインタフェース (WindowsアプリケーションだとMSAA、IAccessible2、UI Automation、Mac OS XアプリケーションではAXAPI、GNOMEアプリケーションでは、GNOME Accessibility Toolkit API、JavaアプリケーションではJava Accessなど)。いくつかの<a href="#def-Platform" title="定義: プラットフォーム" class="termdef">プラットフォーム</a>では<a href="#def-Document-Object" title="定義: ドキュメントオブジェクト" class="termdef">ドキュメントオブジェクト</a>を実装することによって、従来のやりとりをさらに強化してもよい。</dd>
 
     <dt><dfn><a name="def-Plugin" id="def-Plugin"></a>プラグイン (plug-in)</dfn> <!-- [adapted from UAAG 2.0] --> </dt>
@@ -1747,7 +1747,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       <ul>
         <li>コンテンツの処理: <a href="#def-Authoring-Tool" title="定義: オーサリングツール" class="termdef">オーサリングツール</a>が<a class="termdef" href="#def-Web-Content" title="定義: ウェブコンテンツ">ウェブコンテンツ</a>から情報を抽出できるかどうか (<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>からコンテンツの言語を抽出するなど)。</li>
 
-        <li>オーサリングツールと支援技術間のやり取り: <a href="#def-Non-Web-Based" title="定義: 非ウェブベースのユーザインタフェース" class="termdef">非ウェブベースのユーザインタフェース</a>の場合、<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォームアクセシビリティサービス">プラットフォームアクセシビリティサービス</a>やAPI、また場合によってはドキュメントオブジェクトモデルを利用することを意味する。<a class="termdef" href="#def-Web-Based-UI"  title="定義: ウェブベースのユーザインタフェース">ウェブベースのユーザインタフェース</a>の場合は、<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>が (WAI-ARIAの使用などを通じて) 情報を伝えられることを保証することを意味する。
+        <li>オーサリングツールと支援技術間のやり取り: <a href="#def-Non-Web-Based" title="定義: 非ウェブベースのユーザインタフェース" class="termdef">非ウェブベースのユーザインタフェース</a>の場合、<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォームアクセシビリティサービス">プラットフォーム アクセシビリティサービス</a>やAPI、また場合によってはドキュメントオブジェクトモデルを利用することを意味する。<a class="termdef" href="#def-Web-Based-UI"  title="定義: ウェブベースのユーザインタフェース">ウェブベースのユーザインタフェース</a>の場合は、<a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>が (WAI-ARIAの使用などを通じて) 情報を伝えられることを保証することを意味する。
           <br/>
         </li>
       </ul>


### PR DESCRIPTION
「プラットフォーム アクセシビリティサービス」に統一しています。
ただ、1750行目の `title` 属性はスペースなしとしています。
```
title="定義: プラットフォームアクセシビリティサービス"
```