### PR TITLE
未翻訳のtitle属性を訳出 #99

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -369,7 +369,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
  <ul>
   <li>よりシームレスな製品を生み出すことができる</li>
-  <li><a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が既に持つ知識とスキルを活用できる</li>
+  <li><a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>が既に持つ知識とスキルを活用できる</li>
   <li>コンテンツ制作者が新しいアクセシビリティ関連のオーサリングの要件を受け入れやすくなる</li>
   <li>コンテンツ制作者の混乱を減らすことができる</li>
 </ul>
@@ -511,7 +511,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
         <div class="sc-level">
         <h4 class="sc-title"><a id="sc_a222" name="sc_a222"> </a>A.2.2.2 レンダリングされたテキストプロパティへのアクセス:</h4>
-        <p class="sc-title">もし<a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>で<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が編集ビューからも編集できるようなテキスト整形<a href="#def-Web-Content-Properties" title="定義: コンテンツプロパティ (content properties)" class="termdef">プロパティ</a>をレンダリングする場合、そのプロパティは<a class="termdef" href="#def-Programmatically-Determined" title="定義: プログラムによる解釈 (プログラムによる解釈が可能) (programmatically determined (programmatically determinable))">プログラムによる解釈</a>が可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
+        <p class="sc-title">もし<a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>で<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>が編集ビューからも編集できるようなテキスト整形<a href="#def-Web-Content-Properties" title="定義: コンテンツプロパティ (content properties)" class="termdef">プロパティ</a>をレンダリングする場合、そのプロパティは<a class="termdef" href="#def-Programmatically-Determined" title="定義: プログラムによる解釈 (プログラムによる解釈が可能) (programmatically determined (programmatically determinable))">プログラムによる解釈</a>が可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
         <div class="gl-only">
         <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a222">Implementing A.2.2.2</a></div>
 	   </div>
@@ -580,7 +580,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 	        <h4 class="sc-title"><a id="sc_a316" name="sc_a316"> </a> A.3.1.6 キーボードコマンドの提示:</h4>
 
-<p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>がキーボードコマンドを提供している場合、</p>オーサリングツールは<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a> <a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース構成要素">コンポーネント</a>と関連付けられたキーボードコマンドを確認する方法を提供する。<span class="level">（<strong>レベル AAA</strong>）</span>
+<p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>がキーボードコマンドを提供している場合、</p>オーサリングツールは<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>が<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a> <a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース構成要素">コンポーネント</a>と関連付けられたキーボードコマンドを確認する方法を提供する。<span class="level">（<strong>レベル AAA</strong>）</span>
 		    <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a316">Implementing A.3.1.6</a></div>
 	   </div>
@@ -659,7 +659,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 </h3>
 
-    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>は、<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>に存在する構造を利用していると、コンテンツの操作や編集に役立つ場合がある。</p>
+    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>は、<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>に存在する構造を利用していると、コンテンツの操作や編集に役立つ場合がある。</p>
 
     <div class="sc-level">
 
@@ -688,7 +688,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <h3 class="guideline"><a name="gl_a35" id="gl_a35"> </a>ガイドライン A.3.5: （オーサリングツールのユーザインタフェース向け）コンテンツのテキスト検索を提供する。 <span class="gl-only">[<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#gl_a35">Implementing A.3.5</a>] </span>
 </h3>
 
-    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>にとって、<span class="sc-title"><a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a></span>内の任意の箇所に移動するためにテキスト検索を使用できる手段は有効である。</p>
+    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>にとって、<span class="sc-title"><a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a></span>内の任意の箇所に移動するためにテキスト検索を使用できる手段は有効である。</p>
 
 	<div class="sc-level">
 
@@ -766,7 +766,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     </div> <!-- sc-level -->
 
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a372" name="sc_a372"> </a>A.3.7.2 プレビュー（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>が提供されている場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>はどの<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>がプレビューを表示するか選択できる。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a372" name="sc_a372"> </a>A.3.7.2 プレビュー（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>が提供されている場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>はどの<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>がプレビューを表示するか選択できる。<span class="level">（<strong>レベル AAA</strong>）</span></p>
 	  	  	  <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a372">Implementing A.3.7.2</a></div>
 	   </div>
@@ -804,7 +804,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 </div> <!-- sc-level -->
 
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a413" name="sc_a413"> </a>A.4.1.3 コンテンツ変更の可逆性（拡張）: </h4><p class="sc-title"><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は一連の<a href="#def-Reversible-Action" title="定義: 可逆的なオーサリングアクション (reversible authoring action)" class="termdef">可逆的なオーサリングアクション</a>を連続的に可逆可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a413" name="sc_a413"> </a>A.4.1.3 コンテンツ変更の可逆性（拡張）: </h4><p class="sc-title"><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>は一連の<a href="#def-Reversible-Action" title="定義: 可逆的なオーサリングアクション (reversible authoring action)" class="termdef">可逆的なオーサリングアクション</a>を連続的に可逆可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
     <ul class="sc-notes">
     <li class="sc-note"><em class="note-handle">注記:</em> オーサリングアクションの履歴を<a href="#def-End-Auth-Session" title="定義: オーサリングセッションの終了 (end of an authoring session)" class="termdef">オーサリングセッション終了時</a>に削除することは許容可能である。</li>
     </ul>
@@ -848,7 +848,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
         <li class="sc-bullet"><strong class="handle">(a) ドキュメントで説明:</strong> 機能の使用方法はオーサリングツールの<a class="termdef" href="#def-Documentation" title="定義: ドキュメンテーション (documentation)">ドキュメンテーション</a>に記載されている。又は、</li>
         <li class="sc-bullet"><strong class="handle">(b) インタフェース上で説明:</strong> 機能の使用方法は<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a>上に記載されている。又は、</li>
         <li class="sc-bullet"><strong class="handle">(c) プラットフォームサービス:</strong> 機能は基盤となるプラットフォームによって提供されている。又は、</li>
-        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス (platform accessibility service)">プラットフォーム アクセシビリティサービス</a>に渡す).</li>
+        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス (platform accessibility service)">プラットフォーム アクセシビリティサービス</a>に渡す).</li>
       </ul>
       <ul class="sc-notes">
       <li class="sc-note"><em class="note-handle">注記:</em> ドキュメンテーションのアクセシビリティについては<a href="#gl_a11">ガイドライン A.1.1</a>及び<a href="#gl_a11">ガイドライン A.1.2</a>を参照。</li></ul>
@@ -868,7 +868,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 <h3 id="part_b-notes"><a name="part_b_applic_notes" id="part_b_applic_notes"></a>パート B 適合適用性に関する注記:</h3>
 <ol>
-      <li><a name="part_b_applic_note_1" id="part_b_applic_note_1"></a><strong class="handle">コンテンツ制作者が利用できるもの:</strong> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に言及している全てのパート B の達成基準は、<a href="#def-Authoring-Session" title="定義: オーサリングセッション (authoring session)" class="termdef">オーサリングセッション</a>中のみに適用される。</li>
+      <li><a name="part_b_applic_note_1" id="part_b_applic_note_1"></a><strong class="handle">コンテンツ制作者が利用できるもの:</strong> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に言及している全てのパート B の達成基準は、<a href="#def-Authoring-Session" title="定義: オーサリングセッション (authoring session)" class="termdef">オーサリングセッション</a>中のみに適用される。</li>
       <li><strong class="handle"><a name="part_b_applic_note_2" id="part_b_applic_note_2"></a>開発者のコントロール:</strong> パート B の達成基準は、<a class="termdef" href="#def-Developer" title="定義: 開発者 (developer)">開発者</a>が提供する<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>にのみ適用される。これには、オーサリングツール開発者以外の関係者によるその後の変更は含まれない (例えば サードパーティのプラグイン、ユーザ定義<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>、デフォルト設定のユーザ変更など)。</li>
 
       <li><strong class="handle"><a name="part_b_applic_note_3" id="part_b_applic_note_3"></a>オーサリングセッション終了後の適用性:</strong> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、<a href="#def-End-Auth-Session" title="定義: オーサリングセッションの終了 (end of an authoring session)" class="termdef">コンテンツ制作者のオーサリングセッション終了後</a>に<span class="sc"><a href="#def-Content-Auto-Gen" title="定義: 自動生成コンテンツ" class="termdef">自動的に生成される</a></span><a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>の<a href="#def-Accessible-Web-Content" class="termdef" title="定義: アクセシブルなコンテンツ (accessible content) (WCAG)">ウェブコンテンツ アクセシビリティ (WCAG)</a> に対して責任を負う (<a href="#sc_b111">達成基準 B.1.1.1</a> を参照)。例えば、開発者がコンテンツ管理システムのサイト全体の<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を変更した場合、自動的に生成されたコンテンツのアクセシビリティ要件を満たす必要がある。オーサリングツールは、<a class="termdef" href="#def-Content-Author-Gen" title="定義: コンテンツ制作者が生成するコンテンツ">コンテンツ制作者が生成した</a>ものであろうとコンテンツ制作者が指定した他のシステムで自動的に生成されたものであろうと、コンテンツ制作者が引き起こしたコンテンツのアクセシビリティへの変更に対して責任を負わない (例えば、サードパーティのフィードなど)。<br />
@@ -877,7 +877,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       <li><strong class="handle"><a name="part_b_applic_note_4" id="part_b_applic_note_4"></a>オーサリングシステム:</strong> ATAG 2.0 の<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の定義に従い、(<a href="#conf-claim">適合表明</a>で識別された) いくつかのソフトウェアツールを、パート B の要件を満たすために組み合わせて使用できる (例えば、オーサリングツールは、サードパーティのソフトウェアのアクセシビリティ<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>ツールを利用できるなど)。</li>
       <li><strong class="handle"><a name="part_b_applic_note_5" id="part_b_applic_note_5"></a>パート B を満たすために提供される機能のアクセシビリティ:</strong> <a href="#part_a">パート A</a> の達成基準は、パート B の達成基準を満たすために存在しなければならない機能を含んでいる<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a>全体に適用される(例えば、チェックツール、リペアツール、チュートリアル、ドキュメンテーションなど)。</li>
 
-      <li><strong class="handle"><a name="part_b_applic_note_6" id="part_b_applic_note_6"></a>複数のオーサリングの役割:</strong> いくつかの<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、複数の<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>の役割を含んでおり、それぞれの異なるビューとコンテンツの編集<a href="#def-Authoring-Permission" title="定義: 制作者権限 (author permission)" class="termdef">権限</a>がある (例えば コンテンツ管理システムは、デザイナ、コンテンツ作成者及び品質保証者の役割を分けているかもしれないなど)。これらの場合、パート B の達成基準はオーサリングツール全体に適用され、特定のオーサリングの役割に提供されるビューには適用されない。<a class="termdef" href="#def-Accessible-Content-Support-Features" title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)">アクセシブルなコンテンツのサポート機能</a>は、役立つと思われる全てのオーサリングの役割で利用できるようにするべきである。</li>
+      <li><strong class="handle"><a name="part_b_applic_note_6" id="part_b_applic_note_6"></a>複数のオーサリングの役割:</strong> いくつかの<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、複数の<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>の役割を含んでおり、それぞれの異なるビューとコンテンツの編集<a href="#def-Authoring-Permission" title="定義: 制作者権限 (author permission)" class="termdef">権限</a>がある (例えば コンテンツ管理システムは、デザイナ、コンテンツ作成者及び品質保証者の役割を分けているかもしれないなど)。これらの場合、パート B の達成基準はオーサリングツール全体に適用され、特定のオーサリングの役割に提供されるビューには適用されない。<a class="termdef" href="#def-Accessible-Content-Support-Features" title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)">アクセシブルなコンテンツのサポート機能</a>は、役立つと思われる全てのオーサリングの役割で利用できるようにするべきである。</li>
       <li><strong class="handle"><a name="part_b_applic_note_7" id="part_a_applic_note_7"></a>認識できないコンテンツ:</strong> 達成基準がオーサリングツールに対し、セマンティックな基準に沿ってウェブコンテンツを扱うことを要求する場合、その達成基準は、これらのセマンティクスがプログラムによりエンコードされている場合にのみ適用される (例えば、画像を説明するテキストは、この役割がマークアップの中でエンコードされている場合にのみ、<a class="termdef" href="#def-Text-Alternatives" title="非テキストコンテンツに対するテキストによる代替">非テキストコンテンツに対するテキストによる代替</a>として扱われる) 。</li>
     </ol>
 
@@ -1111,7 +1111,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
         <h4 class="sc-title"><a id="sc_b243" name="sc_b243"> </a>B.2.4.3 コンテンツ制作者の作成したテンプレート: </h4>
-        <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="定義: テンプレート選択機構" class="termdef">テンプレートの選択メカニズム</a>を含み、<a href="#def-Accessible-Template" title="定義: アクセシブルなテンプレート (WCAG)" class="termdef">非アクセシブルなテンプレート(WCAG)</a>を<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に許可している場合、コンテンツ制作者は、作成したアクセシブルなテンプレートと非アクセシブルなテンプレートとの区別を表示するためにテンプレートの選択メカニズムを使用できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+        <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="定義: テンプレート選択機構" class="termdef">テンプレートの選択メカニズム</a>を含み、<a href="#def-Accessible-Template" title="定義: アクセシブルなテンプレート (WCAG)" class="termdef">非アクセシブルなテンプレート(WCAG)</a>を<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に許可している場合、コンテンツ制作者は、作成したアクセシブルなテンプレートと非アクセシブルなテンプレートとの区別を表示するためにテンプレートの選択メカニズムを使用できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
 				<ul class="sc-notes">
                   <li class="sc-note"><em class="note-handle">注記:</em> この区別は、アクセシブルなテンプレート (WCAG)、非アクセシブルなテンプレート又は両方の情報を提供することが含まれる。</li>
 	  </ul>
@@ -1207,7 +1207,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <!-- sc-level -->
 <div class="sc-level">
   <h4 class="sc-title"><a id="sc_b314" name="sc_b314"> </a>B.3.1.4 ステータスレポート: </h4>
-  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>を提供する場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は、アクセシビリティチェックの結果に基づくアクセシビリティのステータスレポートを受け取ることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>を提供する場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>は、アクセシビリティチェックの結果に基づくアクセシビリティのステータスレポートを受け取ることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
    <ul class="sc-notes">
 <li class="sc-note"><em class="note-handle">注記:</em> アクセシビリティのステータスレポートのフォーマットは、規定がなく、検出された<a href="#def-Web-Content-Accessibility-Problem" title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)" class="termdef">問題</a>又は <a href="#conf-rel-wcag">WCAG 2.0</a> 適合レベルなどの一覧が含まれているかもしれない。</li></ul>
 
@@ -1275,7 +1275,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <div class="sc-level">
 
   <h4 class="sc-title"><a id="sc_b413" name="sc_b413"> </a>B.4.1.3 機能の無効化の警告: </h4>
-  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>には、<a title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)" class="termdef" href="#def-Accessible-Content-Support-Features">アクセシブルなコンテンツのサポート機能</a>をオフにする<span class="sc-bullet"><a href="#def-Option" title="定義: オプション (option)" class="termdef">オプション</a></span>が含まれていない、又は、これらの機能をオフにできる場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は、<a title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)" class="termdef" href="#def-Web-Content-Accessibility-Problem">コンテンツのアクセシビリティ問題 (WCAG)</a> のリスクが増大することを知らされる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>には、<a title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)" class="termdef" href="#def-Accessible-Content-Support-Features">アクセシブルなコンテンツのサポート機能</a>をオフにする<span class="sc-bullet"><a href="#def-Option" title="定義: オプション (option)" class="termdef">オプション</a></span>が含まれていない、又は、これらの機能をオフにできる場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>は、<a title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)" class="termdef" href="#def-Web-Content-Accessibility-Problem">コンテンツのアクセシビリティ問題 (WCAG)</a> のリスクが増大することを知らされる。<span class="level">(<strong>レベル AA</strong>)</span></p>
   <div class="gl-only">
       <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b413">Implementing B.4.1.3</a></div>
     </div>
@@ -1764,10 +1764,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       </ul>
     </dd>
     <dt><a id="def-Prompt" name="def-Prompt"><dfn>プロンプト (prompt)</dfn></a></dt>
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に判断又は情報の一部を求める<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>からのいくつかの要求。この用語は、すぐに対応する必要がある要求（例えばモーダルダイアログボックス）と緊急性の低い要求（例えばスペルミスのある単語に下線を引く）の両方を対象としている。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に判断又は情報の一部を求める<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>からのいくつかの要求。この用語は、すぐに対応する必要がある要求（例えばモーダルダイアログボックス）と緊急性の低い要求（例えばスペルミスのある単語に下線を引く）の両方を対象としている。</dd>
     <dt><dfn><a name="def-Publishing" id="def-Publishing"></a>公開 (publishing)</dfn></dt>
 
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>や<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>が利用できるようにするあらゆるポイント（例えば、ウェブページのアップロード、wikiの変更のコミット、ライブストリーミング）。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>や<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>が利用できるようにするあらゆるポイント（例えば、ウェブページのアップロード、wikiの変更のコミット、ライブストリーミング）。</dd>
 
 
     <dt><a name="def-Range" id="def-Range"></a><dfn>範囲 (range)</dfn></dt>
@@ -1782,14 +1782,14 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <dd><a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>内で識別された<a class="termdef" href="#def-Web-Content-Accessibility-Problem" title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)">ウェブコンテンツのアクセシビリティの問題</a>が解決されるプロセス。ATAG 2.0は、自動化のレベルの増加に基づいて、3種類の修正を認識する。
       <ul>
 
-        <li><a name="def-Manual-Repairing" id="def-Manual-Repairing"></a><dfn>手動修正 (manual repair):</dfn> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>による修正が行われる場合。これには、制作者が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">オーサリングツール</a>によって提供される指示又は指針によって支援される場合が含まれるが、制作者が実際に修正手順を実行する場合も含まれる。</li>
+        <li><a name="def-Manual-Repairing" id="def-Manual-Repairing"></a><dfn>手動修正 (manual repair):</dfn> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>による修正が行われる場合。これには、制作者が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">オーサリングツール</a>によって提供される指示又は指針によって支援される場合が含まれるが、制作者が実際に修正手順を実行する場合も含まれる。</li>
         <li><a name="def-Semi-Automated-Repairing" id="def-Semi-Automated-Repairing"></a><dfn>半自動修正 (semi-automated repair):</dfn> 部分的にオーサリングツールによって修正されるが、修正を完了するためには制作者の入力又は判断が依然として必要な場合。そして</li>
         <li><a name="def-Automated-Repairing" id="def-Automated-Repairing"></a><dfn>自動修正 (automated repair):</dfn> 制作者によるいかなる介入もなしにオーサリングツールによって自動的に修正される場合。</li>
       </ul>
     </dd>
     <dt><a name="def-Restrictions" id="def-Restrictions"></a><dfn>制約、制限されたウェブコンテンツのオーサリング (restrictions, restricted web content authoring)</dfn></dt>
 
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>で指定できる<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>が特定のコンテンツ（要素、属性、ウィジェットなど）を含めなければならないか、又は含めてはならない場合。多くのオーサリングツールは、何らかの方法でオーサリングを制限することで、アクセシビリティに役立つ可能性（例えば非テキス​​トコンテンツの代替テキストが必要な場合）、もしくはアクセシビリティを損なう可能性（例えば代替テキストを定義するための属性が使えない場合）がある。対照的に、ウェブコンテンツのオーサリングを無制限に許可するオーサリングツール（例えば、多くの<a href="#def-Instruction-Level" title="定義: ソースビュー" class="termdef">ソース編集ビュー</a>）は、特定のコンテンツが含まれるか含まれないかを要求しない。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>が<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>で指定できる<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>が特定のコンテンツ（要素、属性、ウィジェットなど）を含めなければならないか、又は含めてはならない場合。多くのオーサリングツールは、何らかの方法でオーサリングを制限することで、アクセシビリティに役立つ可能性（例えば非テキス​​トコンテンツの代替テキストが必要な場合）、もしくはアクセシビリティを損なう可能性（例えば代替テキストを定義するための属性が使えない場合）がある。対照的に、ウェブコンテンツのオーサリングを無制限に許可するオーサリングツール（例えば、多くの<a href="#def-Instruction-Level" title="定義: ソースビュー" class="termdef">ソース編集ビュー</a>）は、特定のコンテンツが含まれるか含まれないかを要求しない。</dd>
 
     <dt><a name="def-Role" id="def-Role"></a><dfn>役割 (role)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
     <dd>テキスト又は<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>内の構成要素の機能をソフトウェアが識別できる数（例えば、画像がハイパーリンク、コマンドボタン又はチェックボックスなどとして機能することを示す文字列）。</dd>
@@ -1798,10 +1798,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     </dt>
     <dd>順序付けられたセット（例えば、メニュー項目、フォームフィールド）内の項目すべてを、所望の項目に達し活性化されるまで一つずつフォーカスを進めていくいくよう<a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース (keyboard interface)">キーボードインタフェース</a>を使用する。これは、キーボードショートカットやバイパスリンクの使用のようにキーボードで直接アクセスする方法とは対照的である。</dd>
     <dt><a id="def-Web-Content-Technology" name="def-Web-Content-Technology"><dfn>技術（ウェブコンテンツ)(technology (web content))</dfn></a> <!-- [harmonized with WCAG 2.0] --></dt>
-    <dd><a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>によってレンダリング、再生又は実行されるべき符号化された命令のための機構。 ウェブコンテンツ技術は、<a href="#def-Markup-Language" title="定義: マークアップ言語 (markup language)" class="termdef">マークアップ言語</a>、データフォーマット、又はプログラミング言語を含むであろう。ウェブコンテンツ技術は静的なウェブページからマルチメディアプレゼンテーション、動的なWebアプリケーションまで幅広く対応しており、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は単独で、又は組み合わせて使用して<a class="termdef" href="#def-End-Users" title="定義: エンドユーザ (end user)">エンドユーザ</a>エクスペリエンスを作成できるであろう。 ウェブコンテンツ技術のいくつかの一般的な例には、HTML、CSS、SVG、PNG、PDF、Flash、Silverlight、Flex、およびJavaScriptが含まれる。</dd>
+    <dd><a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>によってレンダリング、再生又は実行されるべき符号化された命令のための機構。 ウェブコンテンツ技術は、<a href="#def-Markup-Language" title="定義: マークアップ言語 (markup language)" class="termdef">マークアップ言語</a>、データフォーマット、又はプログラミング言語を含むであろう。ウェブコンテンツ技術は静的なウェブページからマルチメディアプレゼンテーション、動的なWebアプリケーションまで幅広く対応しており、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>は単独で、又は組み合わせて使用して<a class="termdef" href="#def-End-Users" title="定義: エンドユーザ (end user)">エンドユーザ</a>エクスペリエンスを作成できるであろう。 ウェブコンテンツ技術のいくつかの一般的な例には、HTML、CSS、SVG、PNG、PDF、Flash、Silverlight、Flex、およびJavaScriptが含まれる。</dd>
 
     <dt><a id="def-Template" name="def-Template"><dfn>テンプレート (template)</dfn></a></dt>
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>、もしくは<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>のための<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を生成する<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>によって記入されているコンテンツの見本（例えば、文書のテンプレート、コンテンツ管理のテンプレート、プレゼンテーションのテーマ）。 多くの場合、テンプレートは、少なくともいくつかのオーサリング上の決定を事前に指定する。
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>、もしくは<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>のための<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を生成する<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>によって記入されているコンテンツの見本（例えば、文書のテンプレート、コンテンツ管理のテンプレート、プレゼンテーションのテーマ）。 多くの場合、テンプレートは、少なくともいくつかのオーサリング上の決定を事前に指定する。
       <ul>
         <li><dfn><a id="def-Accessible-Template" name="def-Accessible-Template">アクセシブルなテンプレート (accessible templates)(WCAG):</a></dfn> 次の両方に該当する場合、<a href="#conf-rel-wcag">WCAG 2.0</a>の達成基準（レベルA、AA又はAAA）を満たすWebコンテンツを作成するよう記入していけるテンプレート：
           <ol type="a">
@@ -1815,10 +1815,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
     <dt><a id="def-Template-Selection-Mechanism" name="def-Template-Selection-Mechanism"><dfn>テンプレート選択機構 (template selection mechanism)</dfn></a></dt>
-    <dd>標準のファイル選択を超え、新たな<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>のための基礎として使用する、もしくは既存のコンテンツに適用する<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を選択することを<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に可能にする機能。</dd>
+    <dd>標準のファイル選択を超え、新たな<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>のための基礎として使用する、もしくは既存のコンテンツに適用する<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を選択することを<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に可能にする機能。</dd>
 
     <dt><a name="def-Time-Limit" id="def-Time-Limit"></a><dfn>制限時間 (time limit)</dfn></dt>
-    <dd>タスクを実行する（例えば、メッセージを読み取り、アイテムを選択し、変更を保存する）ため<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に提供する時間の量。例：オーサリングセッションのタイムアウト、時間間隔でのプレゼンテーション（例えばチュートリアルビデオ）。</dd>
+    <dd>タスクを実行する（例えば、メッセージを読み取り、アイテムを選択し、変更を保存する）ため<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に提供する時間の量。例：オーサリングセッションのタイムアウト、時間間隔でのプレゼンテーション（例えばチュートリアルビデオ）。</dd>
 
     <dt><a name="def-Tutorial" id="def-Tutorial"></a><dfn>チュートリアル (tutorial)</dfn></dt>
     <dd>複数の部分からなるタスクを実行する手順を提供する<a href="#def-Documentation" title="定義: ドキュメンテーション (documentation)" class="termdef">文書</a>のタイプ。</dd>
@@ -1836,12 +1836,12 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       </ul>
     </dd>
     <dt><a id="def-UI-Component" name="def-UI-Component"><dfn>ユーザインタフェース コンポーネント (user interface component)</dfn></a> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd>明確な一つの機能のための単一の制御として<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に知覚される、<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">ユーザインタフェース</a>又は（<a href="#def-Content-Renderings" title="定義: レンダリングされているコンテンツ (content rendering)" class="termdef">コンテンツのレンダリング</a>を含む）コンテンツ表示の一部。 </dd>
+    <dd>明確な一つの機能のための単一の制御として<a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>に知覚される、<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">ユーザインタフェース</a>又は（<a href="#def-Content-Renderings" title="定義: レンダリングされているコンテンツ (content rendering)" class="termdef">コンテンツのレンダリング</a>を含む）コンテンツ表示の一部。 </dd>
 
     <dt><a name="def-Video" id="def-Video"><dfn>ビデオ (video)</dfn></a> <!-- [adapted from WCAG 2.0] --></dt>
     <dd>写真や動画の技術。ビデオはアニメーション、写真画像、又はその両方で構成することができる。</dd>
     <dt><a id="def-View" name="def-View"><dfn>ビュー (view)</dfn></a></dt>
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a>と対話するために使用するユーザインタフェース機能。 ATAG 2.0は、それらが編集をサポートするかどうかに応じてビューを分類する:
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a>と対話するために使用するユーザインタフェース機能。 ATAG 2.0は、それらが編集をサポートするかどうかに応じてビューを分類する:
       <ul>
 
         <li><a name="def-Editing-View" id="def-Editing-View"></a><dfn>編集ビュー (editing-views):</dfn> コンテンツの一部又はすべてが編集可能であるビュー。又は </li>
@@ -1856,7 +1856,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       </ul>
     </dd>
     <dt><a id="def-Workflow" name="def-Workflow"></a><dfn>ワークフロー (workflow)</dfn></dt>
-    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が配信可能な<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>を生成する際に従う通例の手順又はタスク。 <a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>がアプリケーション（例えば、<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>エディタ、画像エディタ、および検証ツール）の集合で構成されている場合、そのワークフローはアプリケーションの1つ又は複数の使用を含むことができる。 </dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)" class="termdef">コンテンツ制作者</a>が配信可能な<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>を生成する際に従う通例の手順又はタスク。 <a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>がアプリケーション（例えば、<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>エディタ、画像エディタ、および検証ツール）の集合で構成されている場合、そのワークフローはアプリケーションの1つ又は複数の使用を含むことができる。 </dd>
   </dl>
   <hr />
 </div> <!-- sect-definitions -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -360,16 +360,16 @@ div.toc ul.toc li ul.toc li ul.toc li a {
   </ul>
   <p>追加されたATAGの技術資料および教育に関する資料へのリンクについては、<a href="http://www.w3.org/WAI/intro/atag.php">Authoring Tool Accessibility Guidelines (ATAG) Overview</a> を参照。</p>
   <h3><a name="intro_understand_levels_conformance" id="intro_understand_levels_conformance"></a>適合レベル</h3>
-  <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の開発において ATAG 2.0 と <a href="#conf-rel-wcag">WCAG 2.0</a> を併用するプロセスをできる限り容易にするために、 ATAG 2.0 では、A（最低レベル）、AA（中レベル） AAA（最高レベル）という <a href="#conf-rel-wcag">WCAG 2.0</a> の3つの適合レベルのモデルと同じにしている。<span class="gl-only">詳細は「<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#intro_understand_levels_conformance">Understanding Levels of Conformance</a>」を参照。</span></p>
+  <p><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の開発において ATAG 2.0 と <a href="#conf-rel-wcag">WCAG 2.0</a> を併用するプロセスをできる限り容易にするために、 ATAG 2.0 では、A（最低レベル）、AA（中レベル） AAA（最高レベル）という <a href="#conf-rel-wcag">WCAG 2.0</a> の3つの適合レベルのモデルと同じにしている。<span class="gl-only">詳細は「<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#intro_understand_levels_conformance">Understanding Levels of Conformance</a>」を参照。</span></p>
 
 
 
   <h3><a id="intro-integrate_acc_features" name="intro-integrate_acc_features"></a>アクセシビリティ機能の統一</h3>
- <p>ATAG 2.0 を実装する際、<a class="termdef" href="#def-Developer" title="definition: authoring tool developers">オーサリングツールの開発者</a>は、よりアクセシブルなオーサリングをサポートする機能を、<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の他の機能と同じ &quot;ルック・アンド・フィール&quot; になるように注意して統一すべきである。厳密に統一することで次のような可能性が生まれる:</p>
+ <p>ATAG 2.0 を実装する際、<a class="termdef" href="#def-Developer" title="定義: 開発者 (developer)">オーサリングツールの開発者</a>は、よりアクセシブルなオーサリングをサポートする機能を、<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の他の機能と同じ &quot;ルック・アンド・フィール&quot; になるように注意して統一すべきである。厳密に統一することで次のような可能性が生まれる:</p>
 
  <ul>
   <li>よりシームレスな製品を生み出すことができる</li>
-  <li><a class="termdef" href="#def-Author" title="definition: authors">コンテンツ制作者</a>が既に持つ知識とスキルを活用できる</li>
+  <li><a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が既に持つ知識とスキルを活用できる</li>
   <li>コンテンツ制作者が新しいアクセシビリティ関連のオーサリングの要件を受け入れやすくなる</li>
   <li>コンテンツ制作者の混乱を減らすことができる</li>
 </ul>
@@ -511,7 +511,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
         <div class="sc-level">
         <h4 class="sc-title"><a id="sc_a222" name="sc_a222"> </a>A.2.2.2 レンダリングされたテキストプロパティへのアクセス:</h4>
-        <p class="sc-title">もし<a class="termdef" href="#def-Editing-View" title="definition: editing view">編集ビュー</a>で<a class="termdef" href="#def-Author" title="definition: authors">コンテンツ制作者</a>が編集ビューからも編集できるようなテキスト整形<a href="#def-Web-Content-Properties" title="definition: content property" class="termdef">プロパティ</a>をレンダリングする場合、そのプロパティは<a class="termdef" href="#def-Programmatically-Determined" title="definition: programmatically determined">プログラムによる解釈</a>が可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
+        <p class="sc-title">もし<a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>で<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が編集ビューからも編集できるようなテキスト整形<a href="#def-Web-Content-Properties" title="定義: コンテンツプロパティ (content properties)" class="termdef">プロパティ</a>をレンダリングする場合、そのプロパティは<a class="termdef" href="#def-Programmatically-Determined" title="定義: プログラムによる解釈 (プログラムによる解釈が可能) (programmatically determined (programmatically determinable))">プログラムによる解釈</a>が可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
         <div class="gl-only">
         <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a222">Implementing A.2.2.2</a></div>
 	   </div>
@@ -552,7 +552,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_a313" name="sc_a313"></a>A.3.1.3 効率的なキーボードアクセス: </h4>
-      <p class="sc-title"><a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">オーサリングツールのユーザインタフェース</a>は、<a href="#def-Sequential-Keyboard-Access" title="definition: sequential keyboard navigation" class="termdef">順次キーボードアクセス</a>よりも効率的なキーボードアクセスを可能にするメカニズムを取り入れている。<span class="level">（<strong>レベル AA</strong>）</span></p>
+      <p class="sc-title"><a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a>は、<a href="#def-Sequential-Keyboard-Access" title="定義: 順次キーボードアクセス" class="termdef">順次キーボードアクセス</a>よりも効率的なキーボードアクセスを可能にするメカニズムを取り入れている。<span class="level">（<strong>レベル AA</strong>）</span></p>
 	  	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a313">Implementing A.3.1.3</a></div>
 	   </div>
@@ -562,7 +562,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     </div><!-- sc-level -->
 
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a314" name="sc_a314"> </a>A.3.1.4 キーボードアクセス（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>のすべての機能は個々のキーストロークに特定のタイミングを要することなく、<a class="termdef" href="#def-Keyboard-Interface" title="definition: keyboard interface">キーボードインタフェース</a>を通じて操作可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a314" name="sc_a314"> </a>A.3.1.4 キーボードアクセス（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>のすべての機能は個々のキーストロークに特定のタイミングを要することなく、<a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース (keyboard interface)">キーボードインタフェース</a>を通じて操作可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
 	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a314">Implementing A.3.1.4</a></div>
 	   </div>
@@ -570,7 +570,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
 
-<h4 class="sc-title"><a id="sc_a315" name="sc_a315"> </a>A.3.1.5 キーボードアクセスのカスタマイズ: </h4><p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>がキーボードコマンドを提供している場合、それらのキーボードコマンドはカスタマイズ可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+<h4 class="sc-title"><a id="sc_a315" name="sc_a315"> </a>A.3.1.5 キーボードアクセスのカスタマイズ: </h4><p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>がキーボードコマンドを提供している場合、それらのキーボードコマンドはカスタマイズ可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
 	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a315">Implementing A.3.1.5</a></div>
 	   </div>
@@ -580,7 +580,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 	        <h4 class="sc-title"><a id="sc_a316" name="sc_a316"> </a> A.3.1.6 キーボードコマンドの提示:</h4>
 
-<p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>がキーボードコマンドを提供している場合、</p>オーサリングツールは<a class="termdef" href="#def-Author" title="definition: authors">コンテンツ制作者</a>が<a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">オーサリングツールのユーザインタフェース</a> <a class="termdef" href="#def-UI-Component" title="definition: user interface component">コンポーネント</a>と関連付けられたキーボードコマンドを確認する方法を提供する。<span class="level">（<strong>レベル AAA</strong>）</span>
+<p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>がキーボードコマンドを提供している場合、</p>オーサリングツールは<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>が<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a> <a class="termdef" href="#def-UI-Component" title="定義: ユーザインタフェース構成要素">コンポーネント</a>と関連付けられたキーボードコマンドを確認する方法を提供する。<span class="level">（<strong>レベル AAA</strong>）</span>
 		    <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a316">Implementing A.3.1.6</a></div>
 	   </div>
@@ -632,7 +632,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
  <div class="sc-level">
    <h4 class="sc-title"><a id="sc_a324" name="sc_a324"> </a>A.3.2.4 コンテンツ編集の保存（拡張）: </h4>
-   <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>はオーサリングツールを使用した<a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>の編集を自動的に保存するよう設定可能である。<span class="level">（<strong>レベル AAA</strong>）</span> </p>
+   <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>はオーサリングツールを使用した<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>の編集を自動的に保存するよう設定可能である。<span class="level">（<strong>レベル AAA</strong>）</span> </p>
    <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a324">Implementing A.3.2.4</a></div>
       </div>
@@ -659,11 +659,11 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 </h3>
 
-    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="definition: authors">コンテンツ制作者</a>は、<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が<a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>に存在する構造を利用していると、コンテンツの操作や編集に役立つ場合がある。</p>
+    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>は、<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>に存在する構造を利用していると、コンテンツの操作や編集に役立つ場合がある。</p>
 
     <div class="sc-level">
 
-      <h4 class="sc-title"><a id="sc_a341" name="sc_a341"> </a>A.3.4.1 構造からのナビゲート: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="definition: editing view">編集ビュー</a>が<a class="termdef" href="#def-Content-Being-Edited" title="definition: web content being edited">編集中のウェブコンテンツ</a>の中で<a href="#def-Markup" title="definition: markup" class="termdef">マークアップ</a><a href="#def-Element" title="definition: element" class="termdef">要素</a>を表示する場合、マークアップ要素 (例えば、ソースコード、レンダリングされたコンテンツ) は選択可能であり、要素の選択範囲を移動させるナビゲーションメカニズムが提供されている。<span class="level">（<strong>レベル AA</strong>）</span> </p>
+      <h4 class="sc-title"><a id="sc_a341" name="sc_a341"> </a>A.3.4.1 構造からのナビゲート: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a>の中で<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a><a href="#def-Element" title="定義: 要素 (element)" class="termdef">要素</a>を表示する場合、マークアップ要素 (例えば、ソースコード、レンダリングされたコンテンツ) は選択可能であり、要素の選択範囲を移動させるナビゲーションメカニズムが提供されている。<span class="level">（<strong>レベル AA</strong>）</span> </p>
 	  	  	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a341">Implementing A.3.4.1</a></div>
 	   </div>
@@ -672,9 +672,9 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     </div>  <!-- sc-level -->
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a342" name="sc_a342"> </a>A.3.4.2 プログラミングによる関連付けからのナビゲート: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="definition: editing view">編集ビュー</a>が<a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>内のプログラミングによる<a href="#def-Relationships" title="definition: relationships" class="termdef">関連付け</a>の編集を可能にする場合、関連しているコンテンツ間のナビゲーションをサポートするメカニズムが提供されている。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a342" name="sc_a342"> </a>A.3.4.2 プログラミングによる関連付けからのナビゲート: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>内のプログラミングによる<a href="#def-Relationships" title="定義: 関係" class="termdef">関連付け</a>の編集を可能にする場合、関連しているコンテンツ間のナビゲーションをサポートするメカニズムが提供されている。<span class="level">（<strong>レベル AAA</strong>）</span></p>
       <ul class="sc-notes">
-        <li class="sc-note"><em class="note-handle">注記:</em> <span class="sc-title"><a href="#def-Web-Content-Technology" title="definition: technology (Web content)" class="termdef">ウェブコンテンツ技術</a>および<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の性質によって、関連性は、これらに限定するものではないが、要素のネスティング、見出し、ラベリング、プログラミングによる意味付け、及びIDの関連付けが含まれる。</span></li>
+        <li class="sc-note"><em class="note-handle">注記:</em> <span class="sc-title"><a href="#def-Web-Content-Technology" title="定義: 技術(ウェブコンテンツ)" class="termdef">ウェブコンテンツ技術</a>および<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の性質によって、関連性は、これらに限定するものではないが、要素のネスティング、見出し、ラベリング、プログラミングによる意味付け、及びIDの関連付けが含まれる。</span></li>
       </ul>
 	  	  	   <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a342">Implementing A.3.4.2</a></div>
@@ -688,14 +688,14 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <h3 class="guideline"><a name="gl_a35" id="gl_a35"> </a>ガイドライン A.3.5: （オーサリングツールのユーザインタフェース向け）コンテンツのテキスト検索を提供する。 <span class="gl-only">[<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#gl_a35">Implementing A.3.5</a>] </span>
 </h3>
 
-    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="definition: authors">コンテンツ制作者</a>にとって、<span class="sc-title"><a class="termdef" href="#def-Content-Being-Edited" title="definition: web content being edited">編集中のウェブコンテンツ</a></span>内の任意の箇所に移動するためにテキスト検索を使用できる手段は有効である。</p>
+    <p class="rationale">根拠: 一部のタイピングやマウスの操作が困難な<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)"">コンテンツ制作者</a>にとって、<span class="sc-title"><a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a></span>内の任意の箇所に移動するためにテキスト検索を使用できる手段は有効である。</p>
 
 	<div class="sc-level">
 
 	  <h4 class="sc-title"><a id="sc_a351" name="sc_a351"> </a>A.3.5.1 テキスト検索: </h4>
-	  <p class="sc-title">オーサリングツールがテキストベースのコンテンツの<a class="termdef" href="#def-Editing-View" title="definition: editing view">編集ビュー</a>を提供する場合、<a class="termdef" href="#def-Editing-View" title="definition: editing view">編集ビュー</a>が有効にするテキスト検索は次のすべてを満たす: <span class="level">（<strong>レベル AA</strong>）</span></p>
+	  <p class="sc-title">オーサリングツールがテキストベースのコンテンツの<a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>を提供する場合、<a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が有効にするテキスト検索は次のすべてを満たす: <span class="level">（<strong>レベル AA</strong>）</span></p>
       <ul class="sc-bullets">
-      <li class="sc-bullet"><strong class="handle">(a) すべての編集可能なテキスト:</strong> 編集ビューで編集可能なあらゆるテキストコンテンツは検索可能である (<a href="#def-Alternative-Content" title="definition: alternative content" class="termdef">代替コンテンツ</a>を含む) 。及び</li>
+      <li class="sc-bullet"><strong class="handle">(a) すべての編集可能なテキスト:</strong> 編集ビューで編集可能なあらゆるテキストコンテンツは検索可能である (<a href="#def-Alternative-Content" title="定義: 代替コンテンツ (alternative content)" class="termdef">代替コンテンツ</a>を含む) 。及び</li>
       <li class="sc-bullet"><strong class="handle">(b) 一致:</strong> 一致する結果はコンテンツ制作者に提示され、フォーカスが与えられる。及び</li>
       <li class="sc-bullet"><strong class="handle">(c) 一致しない:</strong> 結果が見つからない場合、コンテンツ制作者に通知される。及び</li>
       <li class="sc-bullet"><strong class="handle">(d) 双方向:</strong> 検索は前方又は後方に行うことができる。</li>
@@ -710,7 +710,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <h3 class="guideline"><a name="gl_a36" id="gl_a36"> </a>ガイドライン A.3.6: （オーサリングツールのユーザインタフェース向け）環境設定を管理する。 <span class="gl-only">[<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#gl_a36">Implementing A.3.6</a>] </span>
 </h3>
 
-    <p class="rationale">根拠: 一部の<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は<a href="#def-Publishing" title="definition: 公開" class="termdef">公開された</a><a class="termdef" href="#def-Web-Content" title="定義: ウェブコンテンツ">ウェブコンテンツ</a>向けに定義したい<a class="termdef" href="#def-Presentation" title="定義: 提示">提示</a>形態とは異なる、独自の<a class="termdef" href="#def-Display-Settings" title="定義: 表示設定">表示設定</a>をする必要がある。キーボードと表示のプリファレンス設定を保存及び再読み込みすることができると、時間の経過とともに（例えば疲労によって）ニーズが変わる<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>にとって有益である。</p>
+    <p class="rationale">根拠: 一部の<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は<a href="#def-Publishing" title="定義: 公開" class="termdef">公開された</a><a class="termdef" href="#def-Web-Content" title="定義: ウェブコンテンツ">ウェブコンテンツ</a>向けに定義したい<a class="termdef" href="#def-Presentation" title="定義: 提示">提示</a>形態とは異なる、独自の<a class="termdef" href="#def-Display-Settings" title="定義: 表示設定">表示設定</a>をする必要がある。キーボードと表示のプリファレンス設定を保存及び再読み込みすることができると、時間の経過とともに（例えば疲労によって）ニーズが変わる<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>にとって有益である。</p>
 
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_a361" name="sc_a361"></a>A.3.6.1 独立した表示: </h4>
@@ -726,7 +726,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <div class="sc-level">
 
       <h4 class="sc-title"><strong class="handle"><a id="sc_a362" name="sc_a362"> </a></strong>A.3.6.2 設定の保存: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>に<a href="#def-Display-Settings" title="definition: display settings" class="termdef">表示</a>及び／又は<a href="#def-Control-Settings" title="definition: control settings" class="termdef">コントロールの設定</a>を含む場合、これらの設定は<a href="#def-Authoring-Session" title="definition: authoring session" class="termdef">オーサリングセッション</a>間で保存可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
+      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>に<a href="#def-Display-Settings" title="定義: 表示設定 (display settings)" class="termdef">表示</a>及び／又は<a href="#def-Control-Settings" title="定義: 制御設定 (control settings)" class="termdef">コントロールの設定</a>を含む場合、これらの設定は<a href="#def-Authoring-Session" title="定義: オーサリングセッション (authoring session)" class="termdef">オーサリングセッション</a>間で保存可能である。<span class="level">（<strong>レベル AA</strong>）</span></p>
 	  <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a362">Implementing A.3.6.2</a></div>
       </div>
@@ -735,7 +735,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
       <h4 class="sc-title"><strong class="handle"><a id="sc_a363" name="sc_a363"> </a></strong>A.3.6.3 プラットフォームの設定の適用: </h4>
-      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>がオーサリングツールを用いてより具体的な表示及び制御の設定を選択しない限り、<a class="termdef" href="#def-Platform" title="definition: platform">プラットフォーム</a>の<a href="#def-Display-Settings" title="定義: 表示設定" class="termdef">表示</a>及び<a href="#def-Control-Settings" title="定義: 制御設定" class="termdef">制御設定</a>の変更を尊重する。<span class="level">（<strong>レベル AA</strong>）</span></p>
+      <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>がオーサリングツールを用いてより具体的な表示及び制御の設定を選択しない限り、<a class="termdef" href="#def-Platform" title="定義: プラットフォーム (platform)">プラットフォーム</a>の<a href="#def-Display-Settings" title="定義: 表示設定" class="termdef">表示</a>及び<a href="#def-Control-Settings" title="定義: 制御設定" class="termdef">制御設定</a>の変更を尊重する。<span class="level">（<strong>レベル AA</strong>）</span></p>
 	  	  <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a363">Implementing A.3.6.3</a></div>
 	   </div>
@@ -754,7 +754,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_a371" name="sc_a371"> </a>A.3.7.1 プレビュー（最低限レベル）: </h4><p class="sc-title"><a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>機能が提供されている場合、次に挙げる事項のうち、少なくとも一つを満たしている。<span class="level">（<strong>レベル A</strong>）</span></p>
 	  <ul class="sc-bullets">
-      <li class="sc-bullet"><strong class="handle">(a) 市場のユーザエージェント:</strong> プレビューは<a class="termdef" href="#def-Inmarket-User-Agent" title="definition: 市場のユーザエージェント">市場</a>の<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>を用いてコンテンツをレンダリングする。または、</li>
+      <li class="sc-bullet"><strong class="handle">(a) 市場のユーザエージェント:</strong> プレビューは<a class="termdef" href="#def-Inmarket-User-Agent" title="定義: 市場のユーザエージェント">市場</a>の<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>を用いてコンテンツをレンダリングする。または、</li>
       <li class="sc-bullet"><strong class="handle">(b) UAAG (Level A):</strong> プレビューはUser Agent Accessibility Guidelines 1.0のレベル Aに適合している<cite><a href="#ref-UAAG10">[UAAG10]</a></cite>。</li>
 	  </ul>
 	  	  <div class="gl-only">
@@ -766,7 +766,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     </div> <!-- sc-level -->
 
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a372" name="sc_a372"> </a>A.3.7.2 プレビュー（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Preview" title="definition: preview">プレビュー</a>が提供されている場合、<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>はどの<a class="termdef" href="#def-User-Agent" title="definition: user agent">ユーザエージェント</a>がプレビューを表示するか選択できる。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a372" name="sc_a372"> </a>A.3.7.2 プレビュー（拡張）: </h4><p class="sc-title"><a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>が提供されている場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>はどの<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>がプレビューを表示するか選択できる。<span class="level">（<strong>レベル AAA</strong>）</span></p>
 	  	  	  <div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a372">Implementing A.3.7.2</a></div>
 	   </div>
@@ -804,9 +804,9 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 </div> <!-- sc-level -->
 
     <div class="sc-level">
-      <h4 class="sc-title"><a id="sc_a413" name="sc_a413"> </a>A.4.1.3 コンテンツ変更の可逆性（拡張）: </h4><p class="sc-title"><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>は一連の<a href="#def-Reversible-Action" title="definition: reversible authoring action" class="termdef">可逆的なオーサリングアクション</a>を連続的に可逆可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
+      <h4 class="sc-title"><a id="sc_a413" name="sc_a413"> </a>A.4.1.3 コンテンツ変更の可逆性（拡張）: </h4><p class="sc-title"><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は一連の<a href="#def-Reversible-Action" title="定義: 可逆的なオーサリングアクション (reversible authoring action)" class="termdef">可逆的なオーサリングアクション</a>を連続的に可逆可能である。<span class="level">（<strong>レベル AAA</strong>）</span></p>
     <ul class="sc-notes">
-    <li class="sc-note"><em class="note-handle">注記:</em> オーサリングアクションの履歴を<a href="#def-End-Auth-Session" title="definition: end of an authoring session" class="termdef">オーサリングセッション終了時</a>に削除することは許容可能である。</li>
+    <li class="sc-note"><em class="note-handle">注記:</em> オーサリングアクションの履歴を<a href="#def-End-Auth-Session" title="定義: オーサリングセッションの終了 (end of an authoring session)" class="termdef">オーサリングセッション終了時</a>に削除することは許容可能である。</li>
     </ul>
 	  	<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a413">Implementing A.4.1.3</a></div>
@@ -843,12 +843,12 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_a422" name="sc_a422"> </a>A.4.2.2 すべての機能のドキュメント化: </h4>
-      <p class="sc-title">各<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の機能は、次に挙げる事項のうち、少なくとも一つを満たしている: <span class="level">（<strong>レベル AA</strong>）</span></p>
+      <p class="sc-title">各<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の機能は、次に挙げる事項のうち、少なくとも一つを満たしている: <span class="level">（<strong>レベル AA</strong>）</span></p>
       <ul class="sc-bullets">
-        <li class="sc-bullet"><strong class="handle">(a) ドキュメントで説明:</strong> 機能の使用方法はオーサリングツールの<a class="termdef" href="#def-Documentation" title="definition: documentation">ドキュメンテーション</a>に記載されている。又は、</li>
-        <li class="sc-bullet"><strong class="handle">(b) インタフェース上で説明:</strong> 機能の使用方法は<a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">オーサリングツールのユーザインタフェース</a>上に記載されている。又は、</li>
+        <li class="sc-bullet"><strong class="handle">(a) ドキュメントで説明:</strong> 機能の使用方法はオーサリングツールの<a class="termdef" href="#def-Documentation" title="定義: ドキュメンテーション (documentation)">ドキュメンテーション</a>に記載されている。又は、</li>
+        <li class="sc-bullet"><strong class="handle">(b) インタフェース上で説明:</strong> 機能の使用方法は<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a>上に記載されている。又は、</li>
         <li class="sc-bullet"><strong class="handle">(c) プラットフォームサービス:</strong> 機能は基盤となるプラットフォームによって提供されている。又は、</li>
-        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォーム アクセシビリティサービス</a>に渡す).</li>
+        <li class="sc-bullet"><strong class="handle">(d) コンテンツ制作者によって使用されない:</strong> 機能は<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が直接使用しない (例えば、情報を<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス (platform accessibility service)">プラットフォーム アクセシビリティサービス</a>に渡す).</li>
       </ul>
       <ul class="sc-notes">
       <li class="sc-note"><em class="note-handle">注記:</em> ドキュメンテーションのアクセシビリティについては<a href="#gl_a11">ガイドライン A.1.1</a>及び<a href="#gl_a11">ガイドライン A.1.2</a>を参照。</li></ul>
@@ -868,16 +868,16 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 <h3 id="part_b-notes"><a name="part_b_applic_notes" id="part_b_applic_notes"></a>パート B 適合適用性に関する注記:</h3>
 <ol>
-      <li><a name="part_b_applic_note_1" id="part_b_applic_note_1"></a><strong class="handle">コンテンツ制作者が利用できるもの:</strong> <a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に言及している全てのパート B の達成基準は、<a href="#def-Authoring-Session" title="definition: authoring session" class="termdef">オーサリングセッション</a>中のみに適用される。</li>
-      <li><strong class="handle"><a name="part_b_applic_note_2" id="part_b_applic_note_2"></a>開発者のコントロール:</strong> パート B の達成基準は、<a class="termdef" href="#def-Developer" title="definition: authoring tool developers">開発者</a>が提供する<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>にのみ適用される。これには、オーサリングツール開発者以外の関係者によるその後の変更は含まれない (例えば サードパーティのプラグイン、ユーザ定義<a href="#def-Template" title="definition: template" class="termdef">テンプレート</a>、デフォルト設定のユーザ変更など)。</li>
+      <li><a name="part_b_applic_note_1" id="part_b_applic_note_1"></a><strong class="handle">コンテンツ制作者が利用できるもの:</strong> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に言及している全てのパート B の達成基準は、<a href="#def-Authoring-Session" title="定義: オーサリングセッション (authoring session)" class="termdef">オーサリングセッション</a>中のみに適用される。</li>
+      <li><strong class="handle"><a name="part_b_applic_note_2" id="part_b_applic_note_2"></a>開発者のコントロール:</strong> パート B の達成基準は、<a class="termdef" href="#def-Developer" title="定義: 開発者 (developer)">開発者</a>が提供する<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>にのみ適用される。これには、オーサリングツール開発者以外の関係者によるその後の変更は含まれない (例えば サードパーティのプラグイン、ユーザ定義<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>、デフォルト設定のユーザ変更など)。</li>
 
-      <li><strong class="handle"><a name="part_b_applic_note_3" id="part_b_applic_note_3"></a>オーサリングセッション終了後の適用性:</strong> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、<a href="#def-End-Auth-Session" title="definition: end of an authoring session" class="termdef">コンテンツ制作者のオーサリングセッション終了後</a>に<span class="sc"><a href="#def-Content-Auto-Gen" title="definition: automatically-generated content" class="termdef">自動的に生成される</a></span><a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>の<a href="#def-Accessible-Web-Content" class="termdef" title="definition: accessible web content">ウェブコンテンツ アクセシビリティ (WCAG)</a> に対して責任を負う (<a href="#sc_b111">達成基準 B.1.1.1</a> を参照)。例えば、開発者がコンテンツ管理システムのサイト全体の<a href="#def-Template" title="definition: template" class="termdef">テンプレート</a>を変更した場合、自動的に生成されたコンテンツのアクセシビリティ要件を満たす必要がある。オーサリングツールは、<a class="termdef" href="#def-Content-Author-Gen" title="definition: author generated content">コンテンツ制作者が生成した</a>ものであろうとコンテンツ制作者が指定した他のシステムで自動的に生成されたものであろうと、コンテンツ制作者が引き起こしたコンテンツのアクセシビリティへの変更に対して責任を負わない (例えば、サードパーティのフィードなど)。<br />
+      <li><strong class="handle"><a name="part_b_applic_note_3" id="part_b_applic_note_3"></a>オーサリングセッション終了後の適用性:</strong> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、<a href="#def-End-Auth-Session" title="定義: オーサリングセッションの終了 (end of an authoring session)" class="termdef">コンテンツ制作者のオーサリングセッション終了後</a>に<span class="sc"><a href="#def-Content-Auto-Gen" title="定義: 自動生成コンテンツ" class="termdef">自動的に生成される</a></span><a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>の<a href="#def-Accessible-Web-Content" class="termdef" title="定義: アクセシブルなコンテンツ (accessible content) (WCAG)">ウェブコンテンツ アクセシビリティ (WCAG)</a> に対して責任を負う (<a href="#sc_b111">達成基準 B.1.1.1</a> を参照)。例えば、開発者がコンテンツ管理システムのサイト全体の<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を変更した場合、自動的に生成されたコンテンツのアクセシビリティ要件を満たす必要がある。オーサリングツールは、<a class="termdef" href="#def-Content-Author-Gen" title="定義: コンテンツ制作者が生成するコンテンツ">コンテンツ制作者が生成した</a>ものであろうとコンテンツ制作者が指定した他のシステムで自動的に生成されたものであろうと、コンテンツ制作者が引き起こしたコンテンツのアクセシビリティへの変更に対して責任を負わない (例えば、サードパーティのフィードなど)。<br />
 
       </li>
-      <li><strong class="handle"><a name="part_b_applic_note_4" id="part_b_applic_note_4"></a>オーサリングシステム:</strong> ATAG 2.0 の<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の定義に従い、(<a href="#conf-claim">適合表明</a>で識別された) いくつかのソフトウェアツールを、パート B の要件を満たすために組み合わせて使用できる (例えば、オーサリングツールは、サードパーティのソフトウェアのアクセシビリティ<a href="#def-Checking" title="definition: checking" class="termdef">チェック</a>ツールを利用できるなど)。</li>
-      <li><strong class="handle"><a name="part_b_applic_note_5" id="part_b_applic_note_5"></a>パート B を満たすために提供される機能のアクセシビリティ:</strong> <a href="#part_a">パート A</a> の達成基準は、パート B の達成基準を満たすために存在しなければならない機能を含んでいる<a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">オーサリングツールのユーザインタフェース</a>全体に適用される(例えば、チェックツール、リペアツール、チュートリアル、ドキュメンテーションなど)。</li>
+      <li><strong class="handle"><a name="part_b_applic_note_4" id="part_b_applic_note_4"></a>オーサリングシステム:</strong> ATAG 2.0 の<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の定義に従い、(<a href="#conf-claim">適合表明</a>で識別された) いくつかのソフトウェアツールを、パート B の要件を満たすために組み合わせて使用できる (例えば、オーサリングツールは、サードパーティのソフトウェアのアクセシビリティ<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>ツールを利用できるなど)。</li>
+      <li><strong class="handle"><a name="part_b_applic_note_5" id="part_b_applic_note_5"></a>パート B を満たすために提供される機能のアクセシビリティ:</strong> <a href="#part_a">パート A</a> の達成基準は、パート B の達成基準を満たすために存在しなければならない機能を含んでいる<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">オーサリングツールのユーザインタフェース</a>全体に適用される(例えば、チェックツール、リペアツール、チュートリアル、ドキュメンテーションなど)。</li>
 
-      <li><strong class="handle"><a name="part_b_applic_note_6" id="part_b_applic_note_6"></a>複数のオーサリングの役割:</strong> いくつかの<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、複数の<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>の役割を含んでおり、それぞれの異なるビューとコンテンツの編集<a href="#def-Authoring-Permission" title="definition: author permission" class="termdef">権限</a>がある (例えば コンテンツ管理システムは、デザイナ、コンテンツ作成者及び品質保証者の役割を分けているかもしれないなど)。これらの場合、パート B の達成基準はオーサリングツール全体に適用され、特定のオーサリングの役割に提供されるビューには適用されない。<a class="termdef" href="#def-Accessible-Content-Support-Features" title="definition: accessible content support features">アクセシブルなコンテンツのサポート機能</a>は、役立つと思われる全てのオーサリングの役割で利用できるようにするべきである。</li>
+      <li><strong class="handle"><a name="part_b_applic_note_6" id="part_b_applic_note_6"></a>複数のオーサリングの役割:</strong> いくつかの<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、複数の<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>の役割を含んでおり、それぞれの異なるビューとコンテンツの編集<a href="#def-Authoring-Permission" title="定義: 制作者権限 (author permission)" class="termdef">権限</a>がある (例えば コンテンツ管理システムは、デザイナ、コンテンツ作成者及び品質保証者の役割を分けているかもしれないなど)。これらの場合、パート B の達成基準はオーサリングツール全体に適用され、特定のオーサリングの役割に提供されるビューには適用されない。<a class="termdef" href="#def-Accessible-Content-Support-Features" title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)">アクセシブルなコンテンツのサポート機能</a>は、役立つと思われる全てのオーサリングの役割で利用できるようにするべきである。</li>
       <li><strong class="handle"><a name="part_b_applic_note_7" id="part_a_applic_note_7"></a>認識できないコンテンツ:</strong> 達成基準がオーサリングツールに対し、セマンティックな基準に沿ってウェブコンテンツを扱うことを要求する場合、その達成基準は、これらのセマンティクスがプログラムによりエンコードされている場合にのみ適用される (例えば、画像を説明するテキストは、この役割がマークアップの中でエンコードされている場合にのみ、<a class="termdef" href="#def-Text-Alternatives" title="非テキストコンテンツに対するテキストによる代替">非テキストコンテンツに対するテキストによる代替</a>として扱われる) 。</li>
     </ol>
 
@@ -1099,7 +1099,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_b242" name="sc_b242"> </a>B.2.4.2 テンプレートのアクセシビリティの特定: </h4>
-      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="definition: template selection mechanism" class="termdef">テンプレートの選択メカニズム</a>を含み、非<a href="#def-Accessible-Template" title="definition: accessible templates" class="termdef">アクセシブルなテンプレート (WCAG)</a> <a class="termdef" title="definition: options" href="#def-Option">オプション</a>を提供する場合、テンプレート選択メカニズムは、アクセシブルなオプションと非アクセシブルなオプションとの区別を表示できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="定義: テンプレート選択機構" class="termdef">テンプレートの選択メカニズム</a>を含み、非<a href="#def-Accessible-Template" title="定義: アクセシブルなテンプレート (WCAG)" class="termdef">アクセシブルなテンプレート (WCAG)</a> <a class="termdef" title="定義: オプション (option)" href="#def-Option">オプション</a>を提供する場合、テンプレート選択メカニズムは、アクセシブルなオプションと非アクセシブルなオプションとの区別を表示できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
 	  <ul class="sc-notes">
         <li class="sc-note"><em class="note-handle">注記:</em> この区別は、アクセシブルなテンプレート、非アクセシブルなテンプレート又は両方の情報を提供することが含まれる。</li>
       </ul>
@@ -1111,7 +1111,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
         <h4 class="sc-title"><a id="sc_b243" name="sc_b243"> </a>B.2.4.3 コンテンツ制作者の作成したテンプレート: </h4>
-        <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="definition: template selection mechanism" class="termdef">テンプレートの選択メカニズム</a>を含み、<a href="#def-Accessible-Template" title="definition: accessible templates" class="termdef">非アクセシブルなテンプレート(WCAG)</a>を<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に許可している場合、コンテンツ制作者は、作成したアクセシブルなテンプレートと非アクセシブルなテンプレートとの区別を表示するためにテンプレートの選択メカニズムを使用できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+        <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が、<a href="#def-Template-Selection-Mechanism" title="定義: テンプレート選択機構" class="termdef">テンプレートの選択メカニズム</a>を含み、<a href="#def-Accessible-Template" title="定義: アクセシブルなテンプレート (WCAG)" class="termdef">非アクセシブルなテンプレート(WCAG)</a>を<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に許可している場合、コンテンツ制作者は、作成したアクセシブルなテンプレートと非アクセシブルなテンプレートとの区別を表示するためにテンプレートの選択メカニズムを使用できる。<span class="level">(<strong>レベル AA</strong>)</span></p>
 				<ul class="sc-notes">
                   <li class="sc-note"><em class="note-handle">注記:</em> この区別は、アクセシブルなテンプレート (WCAG)、非アクセシブルなテンプレート又は両方の情報を提供することが含まれる。</li>
 	  </ul>
@@ -1127,7 +1127,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 <div class="sc-level">
   <h4 class="sc-title"><a id="sc_b244" name="sc_b244"> </a>B.2.4.4 アクセシブルなテンプレートオプション(拡張): </h4>
-  <p class="sc-title">  <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が<a href="#def-Template" title="definition: template" class="termdef">テンプレート</a>を提供する場合、全てのテンプレートは、<a href="#def-Accessible-Template" title="definition: accessible templates" class="termdef">アクセシブルなテンプレート (WCAG レベル AA)</a> である。<span class="level">(<strong>レベル AAA</strong>)</span></p>
+  <p class="sc-title">  <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を提供する場合、全てのテンプレートは、<a href="#def-Accessible-Template" title="定義: アクセシブルなテンプレート (WCAG)" class="termdef">アクセシブルなテンプレート (WCAG レベル AA)</a> である。<span class="level">(<strong>レベル AAA</strong>)</span></p>
   		<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b244">Implementing B.2.4.4</a></div>
     </div>
@@ -1138,10 +1138,10 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 </div> <!-- sc-level -->
 
   <h3 class="guideline"><a id="gl_b25" name="gl_b25"> </a> ガイドライン B.2.5: 事前に作成されたアクセシブルなコンテンツでコンテンツ制作者を支援する。 <span class="gl-only">[<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#gl_b25">Implementing B.2.5</a>]</span> </h3>
-    <p class="rationale">根拠: <a href="#def-Accessible-Preauthored-Content" title="definition: accessible pre-authored content" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG)</a> (例えば、クリップアート、同期メディア、ウィジェットなど) の提供には、編集中の<span class="sc"><a class="termdef" href="#def-Content-Being-Edited" title="definition: web content being edited">ウェブコンテンツ (WCAG) のアクセシビリティ</a></span>を直ちに向上し、<a class="termdef" href="#def-Author" title="definition: author">コンテンツ制作者</a>に必要な作業を削減し、アクセシビリティの重要性を明示するなど、いくつかの利点がある。</p>
+    <p class="rationale">根拠: <a href="#def-Accessible-Preauthored-Content" title="定義: アクセシブルなオーサリング済みコンテンツ (WCAG)" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG)</a> (例えば、クリップアート、同期メディア、ウィジェットなど) の提供には、編集中の<span class="sc"><a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">ウェブコンテンツ (WCAG) のアクセシビリティ</a></span>を直ちに向上し、<a class="termdef" href="#def-Author" title="定義: コンテンツ制作者 (authors)">コンテンツ制作者</a>に必要な作業を削減し、アクセシビリティの重要性を明示するなど、いくつかの利点がある。</p>
     <div class="sc-level">
       <h4 class="sc-title"><a id="sc_b251" name="sc_b251"> </a>B.2.5.1 事前に作成されたアクセシブルなコンテンツのオプション: </h4>
-      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が<a href="#def-Preauthored-Content" title="definition: pre-authored content" class="termdef">オーサリング済みのコンテンツ</a>を提供する場合、<span class="rationale"><a href="#def-Accessible-Preauthored-Content" title="definition: accessible pre-authored content" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG レベル AA)</a></span> <a class="termdef" title="definition: options" href="#def-Option">オプション</a>が一通り提供される。<span class="level">(<strong>レベル AA</strong>)</span></p>
+      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Preauthored-Content" title="定義: オーサリング済みコンテンツ (pre-authored content)" class="termdef">オーサリング済みのコンテンツ</a>を提供する場合、<span class="rationale"><a href="#def-Accessible-Preauthored-Content" title="定義: アクセシブルなオーサリング済みコンテンツ (WCAG)" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG レベル AA)</a></span> <a class="termdef" title="定義: オプション (option)" href="#def-Option">オプション</a>が一通り提供される。<span class="level">(<strong>レベル AA</strong>)</span></p>
       <div class="gl-only">
         <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b251">Implementing B.2.5.1</a></div>
       </div>
@@ -1150,7 +1150,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
       <h4 class="sc-title"><a id="sc_b252" name="sc_b252"> </a>B.2.5.2 事前に作成されたコンテンツのアクセシビリティの特定: </h4>
-      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が、<a href="#def-Preauthored-Content-Selection-Mechanism" title="definition: pre-authored content selection mechanism" class="termdef">オーサリング済みコンテンツの選択メカニズム</a>を含み、非<a href="#def-Accessible-Preauthored-Content" title="definition: accessible pre-authored content" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG レベル AA)</a> <a class="termdef" title="definition: options" href="#def-Option">オプション</a>を提供する場合、選択メカニズムは、アクセシブルなオプション及び非アクセシブルなオプションの区別を表示できる。
+      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が、<a href="#def-Preauthored-Content-Selection-Mechanism" title="定義: オーサリング済みコンテンツの選択メカニズム (pre-authored content selection mechanism)" class="termdef">オーサリング済みコンテンツの選択メカニズム</a>を含み、非<a href="#def-Accessible-Preauthored-Content" title="定義: アクセシブルなオーサリング済みコンテンツ (WCAG)" class="termdef">アクセシブルなオーサリング済みコンテンツ (WCAG レベル AA)</a> <a class="termdef" title="定義: オプション (option)" href="#def-Option">オプション</a>を提供する場合、選択メカニズムは、アクセシブルなオプション及び非アクセシブルなオプションの区別を表示できる。
 <span class="level">(<strong>レベル AA</strong>)</span></p>
       <ul class="sc-notes">
         <li class="sc-note"><em class="note-handle">注記:</em> この区別は、アクセシブルなオーサリング済みコンテンツ、非アクセシブルなテンプレート又は両方の情報を提供することが含まれる。</li>
@@ -1207,9 +1207,9 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <!-- sc-level -->
 <div class="sc-level">
   <h4 class="sc-title"><a id="sc_b314" name="sc_b314"> </a>B.3.1.4 ステータスレポート: </h4>
-  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が<a href="#def-Checking" title="definition: checking" class="termdef">チェック</a>を提供する場合、<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>は、アクセシビリティチェックの結果に基づくアクセシビリティのステータスレポートを受け取ることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>を提供する場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は、アクセシビリティチェックの結果に基づくアクセシビリティのステータスレポートを受け取ることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
    <ul class="sc-notes">
-<li class="sc-note"><em class="note-handle">注記:</em> アクセシビリティのステータスレポートのフォーマットは、規定がなく、検出された<a href="#def-Web-Content-Accessibility-Problem" title="definition: Web content accessibility problem" class="termdef">問題</a>又は <a href="#conf-rel-wcag">WCAG 2.0</a> 適合レベルなどの一覧が含まれているかもしれない。</li></ul>
+<li class="sc-note"><em class="note-handle">注記:</em> アクセシビリティのステータスレポートのフォーマットは、規定がなく、検出された<a href="#def-Web-Content-Accessibility-Problem" title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)" class="termdef">問題</a>又は <a href="#conf-rel-wcag">WCAG 2.0</a> 適合レベルなどの一覧が含まれているかもしれない。</li></ul>
 
 		<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b314">Implementing B.3.1.4</a></div>
@@ -1217,7 +1217,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
   <h4 class="sc-title"><a id="sc_b315" name="sc_b315"> </a>B.3.1.5 結果のプログラムによる関連付け: </h4>
-  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が<a href="#def-Checking" title="definition: checking" class="termdef">チェック</a>を提供する場合、<a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、アクセシビリティの<a href="#def-Checking" title="definition: checking" class="termdef">チェック</a>結果を、チェックされた<a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>とプログラムで関連付けることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+  <p class="sc-title"><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>を提供する場合、<a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、アクセシビリティの<a href="#def-Checking" title="定義: アクセシビリティのチェック (checking, accessibility)" class="termdef">チェック</a>結果を、チェックされた<a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>とプログラムで関連付けることができる。<span class="level">(<strong>レベル AA</strong>)</span></p>
    <div class="gl-only">
       <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b315">Implementing B.3.1.5</a></div>
     </div>
@@ -1275,7 +1275,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <div class="sc-level">
 
   <h4 class="sc-title"><a id="sc_b413" name="sc_b413"> </a>B.4.1.3 機能の無効化の警告: </h4>
-  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>には、<a title="definition: accessible content support features" class="termdef" href="#def-Accessible-Content-Support-Features">アクセシブルなコンテンツのサポート機能</a>をオフにする<span class="sc-bullet"><a href="#def-Option" title="definition: option" class="termdef">オプション</a></span>が含まれていない、又は、これらの機能をオフにできる場合、<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>は、<a title="definition: web content accessibility problem" class="termdef" href="#def-Web-Content-Accessibility-Problem">コンテンツのアクセシビリティ問題 (WCAG)</a> のリスクが増大することを知らされる。<span class="level">(<strong>レベル AA</strong>)</span></p>
+  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>には、<a title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)" class="termdef" href="#def-Accessible-Content-Support-Features">アクセシブルなコンテンツのサポート機能</a>をオフにする<span class="sc-bullet"><a href="#def-Option" title="定義: オプション (option)" class="termdef">オプション</a></span>が含まれていない、又は、これらの機能をオフにできる場合、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は、<a title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)" class="termdef" href="#def-Web-Content-Accessibility-Problem">コンテンツのアクセシビリティ問題 (WCAG)</a> のリスクが増大することを知らされる。<span class="level">(<strong>レベル AA</strong>)</span></p>
   <div class="gl-only">
       <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b413">Implementing B.4.1.3</a></div>
     </div>
@@ -1284,7 +1284,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
         <h4 class="sc-title"><a id="sc_b414" name="sc_b414"> </a>B.4.1.4 機能を目立たせる: </h4>
-        <p class="sc-title">全ての<a class="termdef" href="#def-Accessible-Content-Support-Features" title="definition: accessible content support features">アクセシブルなコンテンツのサポート機能</a>は、無効な<a href="#def-Markup" title="definition: markup" class="termdef">マークアップ</a>、シンタックスエラー、スペルミス又は文法エラーのいずれかに関連した機能として<a class="termdef" href="#def-At-Least-As-Prominent" title="definition: At Least As Prominent">少なくとも同程度目立つ</a>。<span class="level">(<strong>レベル AA</strong>)</span> </p>
+        <p class="sc-title">全ての<a class="termdef" href="#def-Accessible-Content-Support-Features" title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)">アクセシブルなコンテンツのサポート機能</a>は、無効な<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>、シンタックスエラー、スペルミス又は文法エラーのいずれかに関連した機能として<a class="termdef" href="#def-At-Least-As-Prominent" title="定義: 少なくとも同程度目立つ">少なくとも同程度目立つ</a>。<span class="level">(<strong>レベル AA</strong>)</span> </p>
 		<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b414">Implementing B.4.1.4</a></div>
 	   </div>
@@ -1325,7 +1325,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 <div class="sc-level">
   <h4 class="sc-title"><a id="sc_b423" name="sc_b423"> </a>B.4.2.3 チュートリアル: </h4>
-  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、そのオーサリングツール固有のアクセシブルなオーサリング処理の<a href="#def-Tutorial" title="definition: tutorial" class="termdef">チュートリアル</a>を提供する。<span class="level">(<strong>レベル AAA</strong>)</span></p>
+  <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、そのオーサリングツール固有のアクセシブルなオーサリング処理の<a href="#def-Tutorial" title="定義: チュートリアル" class="termdef">チュートリアル</a>を提供する。<span class="level">(<strong>レベル AAA</strong>)</span></p>
 		<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b423">Implementing B.4.2.3</a></div>
 </div>
@@ -1333,7 +1333,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
       <h4 class="sc-title"><a id="sc_b424" name="sc_b424"> </a>B.4.2.4 説明の索引: </h4>
-      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の<a class="termdef" href="#def-Documentation" title="definition: documentation">ドキュメンテーション</a>は、<a class="termdef" href="#def-Accessible-Content-Support-Features" title="definition: accessible content support features">アクセシブルなコンテンツのサポート機能</a>を使用するための説明の索引を含む。<span class="level">(<strong>レベル AAA</strong>)</span></p>
+      <p class="sc-title"> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の<a class="termdef" href="#def-Documentation" title="定義: ドキュメンテーション (documentation)">ドキュメンテーション</a>は、<a class="termdef" href="#def-Accessible-Content-Support-Features" title="定義: アクセシブルなコンテンツのサポート機能 (accessible content support features)">アクセシブルなコンテンツのサポート機能</a>を使用するための説明の索引を含む。<span class="level">(<strong>レベル AAA</strong>)</span></p>
 	  		<div class="gl-only">
 	     <div class="implementing-link"><a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_b424">Implementing B.4.2.4</a></div>
 	   </div>
@@ -1403,14 +1403,14 @@ div.toc ul.toc li ul.toc li ul.toc li a {
   <p> <em>注記 1:</em> 追加のオーサリングプロセスコンポーネントが (例えば、セキュリティ上の理由のため) 失敗した達成基準を満たさないように防ぐ場合、オーサリングツールは部分適合を満たすことができないだろう。<br />
     <em>注記 2:</em> <a href="#part_a_applic_notes">パート A の適合適用性に関する注記</a>及び<a href="#part_b_applic_notes">パート B の適合適用性に関する注記</a>が適用されなければならない。 </p>
   <h5><a name="conf-partial-platform-limits" id="conf-partial-platform-limits"></a>ATAG 2.0 部分適合 - プラットフォームの制限（レベルA、AA、またはAAA）</h5>
-  <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>が (例えば、<a class="termdef" href="#def-Accessibility-Platform-Service" title="definition: accessibility platform architecture">プラットフォーム アクセシビリティサービス</a>を欠いているなど) <a class="termdef" href="#def-Platform" title="definition: platform">プラットフォーム</a>固有の制限のために一つ以上の達成基準を満たすことができない場合、この適合オプションが選択されてもよい。(任意の) 適合表明の結果の説明は、どのプラットフォームの機能が欠けているかを説明することが望ましい。 </p>
+  <p><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>が (例えば、<a class="termdef" href="#def-Accessibility-Platform-Service" title="定義: プラットフォーム アクセシビリティサービス (platform accessibility service)">プラットフォーム アクセシビリティサービス</a>を欠いているなど) <a class="termdef" href="#def-Platform" title="定義: プラットフォーム (platform)">プラットフォーム</a>固有の制限のために一つ以上の達成基準を満たすことができない場合、この適合オプションが選択されてもよい。(任意の) 適合表明の結果の説明は、どのプラットフォームの機能が欠けているかを説明することが望ましい。 </p>
 
   <h4><a name="conf-techs-produced" id="conf-techs-produced"> </a>ウェブコンテンツ技術の制作:</h4>
-  <p><a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>は、特定の<a class="termdef" href="#def-Web-Content-Technology" title="definition: technology (Web content)">ウェブコンテンツ技術</a>の制作物に関して ATAG 2.0 に適合する (例えば、XHTML 1.0 の制作物に関して、レベル A 適合)。</p>
+  <p><a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>は、特定の<a class="termdef" href="#def-Web-Content-Technology" title="定義: 技術(ウェブコンテンツ)">ウェブコンテンツ技術</a>の制作物に関して ATAG 2.0 に適合する (例えば、XHTML 1.0 の制作物に関して、レベル A 適合)。</p>
 
-  <p>オーサリングツールが複数のウェブコンテンツ技術を制作する能力がある場合、<a class="termdef" href="#def-Developer" title="definition: authoring tool developers">開発者</a>が<a href="#def-Content-Auto-Gen" title="definition: automatically-generated content" class="termdef">自動的に生成されたコンテンツ</a>を設定する、又は開発者が<a class="termdef" href="#def-Content-Author-Gen" title="definition: author generated content">コンテンツ制作者生成コンテンツ</a>のデフォルトとして設定する、両方の任意の技術を含む限り、適合は複数のウェブコンテンツ技術のサブセットのみを含んでもよい。これは必須ではないものの、<a href="#def-End-Users" title="definition: end user" class="termdef">エンドユーザ</a>に<a href="#def-Publishing" title="definition: publishing" class="termdef">公開する</a>ことを意図しない「中間」形式を含んでもよい。  </p>
+  <p>オーサリングツールが複数のウェブコンテンツ技術を制作する能力がある場合、<a class="termdef" href="#def-Developer" title="定義: 開発者 (developer)">開発者</a>が<a href="#def-Content-Auto-Gen" title="定義: 自動生成コンテンツ" class="termdef">自動的に生成されたコンテンツ</a>を設定する、又は開発者が<a class="termdef" href="#def-Content-Author-Gen" title="定義: コンテンツ制作者が生成するコンテンツ">コンテンツ制作者生成コンテンツ</a>のデフォルトとして設定する、両方の任意の技術を含む限り、適合は複数のウェブコンテンツ技術のサブセットのみを含んでもよい。これは必須ではないものの、<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>に<a href="#def-Publishing" title="定義: 公開" class="termdef">公開する</a>ことを意図しない「中間」形式を含んでもよい。  </p>
   <h4><a name="conf-live-publishing" id="conf-live-publishing"></a>ライブパブリッシングオーサリングツール: </h4>
-  <p>ATAG 2.0 は、ウェブコンテンツのライブオーサリング (例えば、いくつかのコラボレーションツール) を伴うワークフローをオーサリングツールに適用してもよい。 リアルタイム発行に固有の問題のため、これらのオーサリングツールの ATAG 2.0 <a href="#part_b">パート B</a> への適合は、ライブ<span class="sc"><a href="#def-Authoring-Session" title="definition: authoring session" class="termdef">オーサリングセッション</a></span>の前 (例えば、アクセシブルなスライドの準備におけるサポート)、間 (例えば、WCAG 2.0 がレベル AA で要求されるライブキャプション)、及び後 (例えば、リアルタイムで最初に公開されたプレゼンテーションのアーカイブにトランスクリプトを追加する機能など) のいくつかの組み合わせを伴ってもよい。詳細については、<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#realtime-production">Implementing ATAG 2.0 - Appendix E: Authoring Tools for Live Web Content</a>を参照のこと。</p>
+  <p>ATAG 2.0 は、ウェブコンテンツのライブオーサリング (例えば、いくつかのコラボレーションツール) を伴うワークフローをオーサリングツールに適用してもよい。 リアルタイム発行に固有の問題のため、これらのオーサリングツールの ATAG 2.0 <a href="#part_b">パート B</a> への適合は、ライブ<span class="sc"><a href="#def-Authoring-Session" title="定義: オーサリングセッション (authoring session)" class="termdef">オーサリングセッション</a></span>の前 (例えば、アクセシブルなスライドの準備におけるサポート)、間 (例えば、WCAG 2.0 がレベル AA で要求されるライブキャプション)、及び後 (例えば、リアルタイムで最初に公開されたプレゼンテーションのアーカイブにトランスクリプトを追加する機能など) のいくつかの組み合わせを伴ってもよい。詳細については、<a href="http://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#realtime-production">Implementing ATAG 2.0 - Appendix E: Authoring Tools for Live Web Content</a>を参照のこと。</p>
 
   <h3><a name="conf-claim" id="conf-claim"> </a>適合表明（任意）</h3>
   <p><em>注記:</em> 任意のソフトウェアアプリケーションと同様に、オーサリングツールは、コンポーネントの集まりとすることができる。適合表明は、責任主体によってのみ行うことができる。その他の計画された「表明」は、実際には、レビューである。</p>
@@ -1420,20 +1420,20 @@ div.toc ul.toc li ul.toc li ul.toc li a {
     <li>表明<strong>日</strong></li>
     <li><strong>ATAG 2.0 </strong>の<strong>バージョン</strong>及び <strong>URI</strong></li>
     <li>満足する<a href="#conf-levels"><strong>適合レベル</strong></a>。</li>
-    <li><strong>オーサリングツール情報:</strong> <a class="termdef" href="#def-Authoring-Tool" title="definition: authoring tool">オーサリングツール</a>の名前及びバージョンを指定するのに十分な追加情報 (例えば、ベンダ名、バージョン番号 (又はバージョンの範囲)、必要なパッチ又は更新、ユーザインタフェース又は<a class="termdef" href="#def-Documentation" title="definition: documentation">文書</a>の<a class="termdef" href="#def-Human-Language" title="definition: human language">自然言語</a>)。
+    <li><strong>オーサリングツール情報:</strong> <a class="termdef" href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)">オーサリングツール</a>の名前及びバージョンを指定するのに十分な追加情報 (例えば、ベンダ名、バージョン番号 (又はバージョンの範囲)、必要なパッチ又は更新、ユーザインタフェース又は<a class="termdef" href="#def-Documentation" title="定義: ドキュメンテーション (documentation)">文書</a>の<a class="termdef" href="#def-Human-Language" title="定義: 自然言語 (human language)">自然言語</a>)。
       <ul>
-        <li><em>注記:</em> オーサリングツールが、ソフトウェアアプリケーション (例えば、<a href="#def-Markup" title="definition: markup" class="termdef">マークアップ</a>エディタ、画像エディタ、検証ツールなど) の集合である場合、適合表明は全体としてアプリケーションを処理するが、情報は、アプリケーションごとに個別に設けなければならない。</li>
+        <li><em>注記:</em> オーサリングツールが、ソフトウェアアプリケーション (例えば、<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>エディタ、画像エディタ、検証ツールなど) の集合である場合、適合表明は全体としてアプリケーションを処理するが、情報は、アプリケーションごとに個別に設けなければならない。</li>
 
       </ul>
     </li>
-    <li><strong>プラットフォーム:</strong> オーサリングツールが影響する<a class="termdef" href="#def-Platform" title="definition: platform">プラットフォーム</a>
+    <li><strong>プラットフォーム:</strong> オーサリングツールが影響する<a class="termdef" href="#def-Platform" title="定義: プラットフォーム (platform)">プラットフォーム</a>
       <ul>
-        <li><a name="conf-user-agents" id="conf-user-agents"></a>(<a class="termdef" href="#def-Web-Based-UI" title="definition: authoring tool user interface (Web-based)">ウェブベースのオーサリングツール</a>のユーザインタフェースを評価するために使用される) <strong><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>プラットフォーム</strong>の場合: ユーザエージェントの名前及びバージョン情報を提供する。</li>
+        <li><a name="conf-user-agents" id="conf-user-agents"></a>(<a class="termdef" href="#def-Web-Based-UI" title="定義: オーサリングツールのユーザインタフェース (ウェブベース) (authoring tool user interface (web-based))">ウェブベースのオーサリングツール</a>のユーザインタフェースを評価するために使用される) <strong><a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>プラットフォーム</strong>の場合: ユーザエージェントの名前及びバージョン情報を提供する。</li>
 
-        <li> <a name="conf-not-user-agents" id="conf-not-user-agents"></a>(<a class="termdef" href="#def-Non-Web-Based" title="definition: authoring tool user interface (non-Web-Based)">非ウェブベースのオーサリングツールのユーザインタフェース</a>を評価するために使用される) <strong><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>ではないプラットフォーム</strong>の場合: プラットフォーム (例えばデスクトップオペレーティングシステム、モバイルオペレーティングシステム、クロス OS 環境) の名前及びバージョン情報並びに採用された<a href="#def-Accessibility-Platform-Service" title="definition: platform accessibility architectur" class="termdef">プラットフォーム アクセシビリティサービス</a>の名前及びバージョンを提供する。</li>
+        <li> <a name="conf-not-user-agents" id="conf-not-user-agents"></a>(<a class="termdef" href="#def-Non-Web-Based" title="定義: オーサリングツールのユーザインタフェース (非ウェブベース) (authoring tool user interface (non-web-based))">非ウェブベースのオーサリングツールのユーザインタフェース</a>を評価するために使用される) <strong><a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>ではないプラットフォーム</strong>の場合: プラットフォーム (例えばデスクトップオペレーティングシステム、モバイルオペレーティングシステム、クロス OS 環境) の名前及びバージョン情報並びに採用された<a href="#def-Accessibility-Platform-Service" title="定義: " class="termdef">プラットフォーム アクセシビリティサービス</a>の名前及びバージョンを提供する。</li>
       </ul>
     </li>
-    <li><strong>表明に含まれているオーサリングツールによって生成されたウェブコンテンツ技術</strong>のリスト。適合表明に含まれていないオーサリングツールによって<a href="#conf-techs-produced">生成される</a>任意の<a class="termdef" href="#def-Web-Content-Technology" title="definition: technology (Web content)">ウェブコンテンツ技術</a>が存在する場合、個別に列挙されなければならない。オーサリングツールがデフォルトで任意のウェブコンテンツ技術を生成する場合、これは含まれていなければならない。</li>
+    <li><strong>表明に含まれているオーサリングツールによって生成されたウェブコンテンツ技術</strong>のリスト。適合表明に含まれていないオーサリングツールによって<a href="#conf-techs-produced">生成される</a>任意の<a class="termdef" href="#def-Web-Content-Technology" title="定義: 技術(ウェブコンテンツ)">ウェブコンテンツ技術</a>が存在する場合、個別に列挙されなければならない。オーサリングツールがデフォルトで任意のウェブコンテンツ技術を生成する場合、これは含まれていなければならない。</li>
     <li><strong>各達成基準の結果:</strong> はい、いいえ、<a href="#conf-applic">該当なし</a></li>
 
   </ol>
@@ -1441,7 +1441,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
   <p>上記の適合表明の必須項目に加えて、コンテンツ制作者を支援するために追加情報を提供することを検討する。追加する情報として推奨するものを以下に挙げる:</p>
   <ol>
     <li><a name="conf-explanation-results" id="conf-explanation-results"></a> <strong>達成基準の結果の説明</strong> (はい、いいえ)。(強く推奨する)</li>
-    <li>生成されたウェブコンテンツ技術がどのように<a class="termdef" href="#def-Accessible-Web-Content" title="definition: accessible Web content">アクセシブルなウェブコンテンツ</a>を生成するために使用できるかについての情報 (例えば、技術特有の WCAG 2.0 達成方法へのリンク) 。</li>
+    <li>生成されたウェブコンテンツ技術がどのように<a class="termdef" href="#def-Accessible-Web-Content" title="定義: アクセシブルなコンテンツ (accessible content) (WCAG)">アクセシブルなウェブコンテンツ</a>を生成するために使用できるかについての情報 (例えば、技術特有の WCAG 2.0 達成方法へのリンク) 。</li>
     <li>アクセシビリティを向上させるために達成基準を超えて追加で施した措置に関する情報。</li>
     <li>適合表明の機械的に読み取れるメタデータ版。 </li>
     <li>オーサリングツールの編集ビューの種類を特定するオーサリングツールの説明。</li>
@@ -1760,52 +1760,52 @@ div.toc ul.toc li ul.toc li ul.toc li a {
         <em> 注記 2:</em> 「オープニングアクション (Opening actions)」は、新しいコンポーネントを表示、又は有効とするために、コンテンツ制作者がユーザインタフェースの中のコンポーネントに対して起こすアクションである。
         例 : (a) サブメニューを表示するためのトップレベルメニューアイテムのキーボードショートカット、(b) ダイアログボックスを表示するためのボタンをキーボードで選択する、(c) 無効だったサブアイテムを有効にするためにチェックボックスをマウスでクリックするなど。新しいコンポーネントをアクション可能にしないアクション (フォーカスを移動する、リストをスクロールする)、は「オープニングアクション (opening actions)」としてカウントしない。<br />
         <em> 注記 3:</em> 閉じられたコンテナ内のコンポーネントへのキーボードショートカットは、表示されていないコンポーネントが表示されるのではないため、&quot;オープニングアクション&quot; としてみなされない。閉じられたコンテナ内のコンポーネントを表示するために  &quot;検索&quot; を使う必要がある場合も同じことが言える。<br />
-        <em> 注記 4:</em> &quot;デフォルト状態&quot; は、開発者により設定されたオーサリングセッション開始時の<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>の状態である。 多くのドキュメントオーサリングツールのデフォルト状態は<a href="#def-Editing-View" title="definition: editing views" class="termdef">編集ビュー</a>である。 </li>
+        <em> 注記 4:</em> &quot;デフォルト状態&quot; は、開発者により設定されたオーサリングセッション開始時の<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>の状態である。 多くのドキュメントオーサリングツールのデフォルト状態は<a href="#def-Editing-View" title="定義: 編集ビュー" class="termdef">編集ビュー</a>である。 </li>
       </ul>
     </dd>
     <dt><a id="def-Prompt" name="def-Prompt"><dfn>プロンプト (prompt)</dfn></a></dt>
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に判断又は情報の一部を求める<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>からのいくつかの要求。この用語は、すぐに対応する必要がある要求（例えばモーダルダイアログボックス）と緊急性の低い要求（例えばスペルミスのある単語に下線を引く）の両方を対象としている。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に判断又は情報の一部を求める<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>からのいくつかの要求。この用語は、すぐに対応する必要がある要求（例えばモーダルダイアログボックス）と緊急性の低い要求（例えばスペルミスのある単語に下線を引く）の両方を対象としている。</dd>
     <dt><dfn><a name="def-Publishing" id="def-Publishing"></a>公開 (publishing)</dfn></dt>
 
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>や<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>が<a href="#def-Web-Content" title="definition: web content" class="termdef">ウェブコンテンツ</a>を<a href="#def-End-Users" title="definition: end user" class="termdef">エンドユーザ</a>が利用できるようにするあらゆるポイント（例えば、ウェブページのアップロード、wikiの変更のコミット、ライブストリーミング）。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>や<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>が利用できるようにするあらゆるポイント（例えば、ウェブページのアップロード、wikiの変更のコミット、ライブストリーミング）。</dd>
 
 
     <dt><a name="def-Range" id="def-Range"></a><dfn>範囲 (range)</dfn></dt>
     <dd>複数項目の集合内での複数の項目。<br/>
-    <em>参考的な注記 :</em> ATAG2.0は、絶対測定が実用的でない場合、用語 &quot;範囲&quot; を使用する（例えば、全てのヘルプ<a href="#def-Documentation" title="definition: documentation" class="termdef">文書</a>例の集合、全ての<a href="#def-Template" title="definition: template" class="termdef">テンプレート</a>の集合）。厳密にテスト可能な要件は &quot;複数項目セット内の複数の項目&quot; の定義であるが、実装者は達成基準をより広範に実装することを強く推奨する。<br />
+    <em>参考的な注記 :</em> ATAG2.0は、絶対測定が実用的でない場合、用語 &quot;範囲&quot; を使用する（例えば、全てのヘルプ<a href="#def-Documentation" title="定義: ドキュメンテーション (documentation)" class="termdef">文書</a>例の集合、全ての<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>の集合）。厳密にテスト可能な要件は &quot;複数項目セット内の複数の項目&quot; の定義であるが、実装者は達成基準をより広範に実装することを強く推奨する。<br />
 <em>訳注：</em>基準器との比較により測定することを比較測定又は間接測定と呼び、対して測定機器で直接測定することを絶対測定又は直接測定と呼ぶ。</dd>
 
     <dt><a name="def-Relationships" id="def-Relationships"></a><dfn>関係 (relationships)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd>異なる<a href="#def-Web-Content" title="definition: web content" class="termdef">コンテンツ</a>間の意味のある関連付け。</dd>
+    <dd>異なる<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>間の意味のある関連付け。</dd>
 
     <dt><a id="def-Repairing" name="def-Repairing"></a><dfn>修正 (アクセシビリティ)(repair (accessibility))</dfn> <!-- [harmonized with EARL 1.0] --></dt>
-    <dd><a class="termdef" href="#def-Web-Content" title="definition: web content">ウェブコンテンツ</a>内で識別された<a class="termdef" href="#def-Web-Content-Accessibility-Problem" title="definition: web content accessibility problem">ウェブコンテンツのアクセシビリティの問題</a>が解決されるプロセス。ATAG 2.0は、自動化のレベルの増加に基づいて、3種類の修正を認識する。
+    <dd><a class="termdef" href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))">ウェブコンテンツ</a>内で識別された<a class="termdef" href="#def-Web-Content-Accessibility-Problem" title="定義: ウェブコンテンツのアクセシビリティの問題 (WCAG)">ウェブコンテンツのアクセシビリティの問題</a>が解決されるプロセス。ATAG 2.0は、自動化のレベルの増加に基づいて、3種類の修正を認識する。
       <ul>
 
-        <li><a name="def-Manual-Repairing" id="def-Manual-Repairing"></a><dfn>手動修正 (manual repair):</dfn> <a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>による修正が行われる場合。これには、制作者が<a href="#def-Author" title="definition: authors" class="termdef">オーサリングツール</a>によって提供される指示又は指針によって支援される場合が含まれるが、制作者が実際に修正手順を実行する場合も含まれる。</li>
+        <li><a name="def-Manual-Repairing" id="def-Manual-Repairing"></a><dfn>手動修正 (manual repair):</dfn> <a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>による修正が行われる場合。これには、制作者が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">オーサリングツール</a>によって提供される指示又は指針によって支援される場合が含まれるが、制作者が実際に修正手順を実行する場合も含まれる。</li>
         <li><a name="def-Semi-Automated-Repairing" id="def-Semi-Automated-Repairing"></a><dfn>半自動修正 (semi-automated repair):</dfn> 部分的にオーサリングツールによって修正されるが、修正を完了するためには制作者の入力又は判断が依然として必要な場合。そして</li>
         <li><a name="def-Automated-Repairing" id="def-Automated-Repairing"></a><dfn>自動修正 (automated repair):</dfn> 制作者によるいかなる介入もなしにオーサリングツールによって自動的に修正される場合。</li>
       </ul>
     </dd>
     <dt><a name="def-Restrictions" id="def-Restrictions"></a><dfn>制約、制限されたウェブコンテンツのオーサリング (restrictions, restricted web content authoring)</dfn></dt>
 
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>で指定できる<a href="#def-Web-Content" title="definition: web content" class="termdef">ウェブコンテンツ</a>が特定のコンテンツ（要素、属性、ウィジェットなど）を含めなければならないか、又は含めてはならない場合。多くのオーサリングツールは、何らかの方法でオーサリングを制限することで、アクセシビリティに役立つ可能性（例えば非テキス​​トコンテンツの代替テキストが必要な場合）、もしくはアクセシビリティを損なう可能性（例えば代替テキストを定義するための属性が使えない場合）がある。対照的に、ウェブコンテンツのオーサリングを無制限に許可するオーサリングツール（例えば、多くの<a href="#def-Instruction-Level" title="definition: View - Source view" class="termdef">ソース編集ビュー</a>）は、特定のコンテンツが含まれるか含まれないかを要求しない。</dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>で指定できる<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>が特定のコンテンツ（要素、属性、ウィジェットなど）を含めなければならないか、又は含めてはならない場合。多くのオーサリングツールは、何らかの方法でオーサリングを制限することで、アクセシビリティに役立つ可能性（例えば非テキス​​トコンテンツの代替テキストが必要な場合）、もしくはアクセシビリティを損なう可能性（例えば代替テキストを定義するための属性が使えない場合）がある。対照的に、ウェブコンテンツのオーサリングを無制限に許可するオーサリングツール（例えば、多くの<a href="#def-Instruction-Level" title="定義: ソースビュー" class="termdef">ソース編集ビュー</a>）は、特定のコンテンツが含まれるか含まれないかを要求しない。</dd>
 
     <dt><a name="def-Role" id="def-Role"></a><dfn>役割 (role)</dfn> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd>テキスト又は<a href="#def-Web-Content" title="definition: web content" class="termdef">ウェブコンテンツ</a>内の構成要素の機能をソフトウェアが識別できる数（例えば、画像がハイパーリンク、コマンドボタン又はチェックボックスなどとして機能することを示す文字列）。</dd>
+    <dd>テキスト又は<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>内の構成要素の機能をソフトウェアが識別できる数（例えば、画像がハイパーリンク、コマンドボタン又はチェックボックスなどとして機能することを示す文字列）。</dd>
     <dt><dfn><a name="def-Sequential-Keyboard-Access" id="def-Sequential-Keyboard-Access"></a>順次キーボードアクセス (sequential keyboard access)</dfn>
       <!-- [adapted from UAAG 1.0] -->
     </dt>
-    <dd>順序付けられたセット（例えば、メニュー項目、フォームフィールド）内の項目すべてを、所望の項目に達し活性化されるまで一つずつフォーカスを進めていくいくよう<a class="termdef" href="#def-Keyboard-Interface" title="definition: keyboard interface">キーボードインタフェース</a>を使用する。これは、キーボードショートカットやバイパスリンクの使用のようにキーボードで直接アクセスする方法とは対照的である。</dd>
+    <dd>順序付けられたセット（例えば、メニュー項目、フォームフィールド）内の項目すべてを、所望の項目に達し活性化されるまで一つずつフォーカスを進めていくいくよう<a class="termdef" href="#def-Keyboard-Interface" title="定義: キーボードインタフェース (keyboard interface)">キーボードインタフェース</a>を使用する。これは、キーボードショートカットやバイパスリンクの使用のようにキーボードで直接アクセスする方法とは対照的である。</dd>
     <dt><a id="def-Web-Content-Technology" name="def-Web-Content-Technology"><dfn>技術（ウェブコンテンツ)(technology (web content))</dfn></a> <!-- [harmonized with WCAG 2.0] --></dt>
-    <dd><a href="#def-User-Agent" title="definition: user agent" class="termdef">ユーザエージェント</a>によってレンダリング、再生又は実行されるべき符号化された命令のための機構。 ウェブコンテンツ技術は、<a href="#def-Markup-Language" title="definition: markup language" class="termdef">マークアップ言語</a>、データフォーマット、又はプログラミング言語を含むであろう。ウェブコンテンツ技術は静的なウェブページからマルチメディアプレゼンテーション、動的なWebアプリケーションまで幅広く対応しており、<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>は単独で、又は組み合わせて使用して<a class="termdef" href="#def-End-Users" title="definition: end user">エンドユーザ</a>エクスペリエンスを作成できるであろう。 ウェブコンテンツ技術のいくつかの一般的な例には、HTML、CSS、SVG、PNG、PDF、Flash、Silverlight、Flex、およびJavaScriptが含まれる。</dd>
+    <dd><a href="#def-User-Agent" title="定義: ユーザエージェント" class="termdef">ユーザエージェント</a>によってレンダリング、再生又は実行されるべき符号化された命令のための機構。 ウェブコンテンツ技術は、<a href="#def-Markup-Language" title="定義: マークアップ言語 (markup language)" class="termdef">マークアップ言語</a>、データフォーマット、又はプログラミング言語を含むであろう。ウェブコンテンツ技術は静的なウェブページからマルチメディアプレゼンテーション、動的なWebアプリケーションまで幅広く対応しており、<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>は単独で、又は組み合わせて使用して<a class="termdef" href="#def-End-Users" title="定義: エンドユーザ (end user)">エンドユーザ</a>エクスペリエンスを作成できるであろう。 ウェブコンテンツ技術のいくつかの一般的な例には、HTML、CSS、SVG、PNG、PDF、Flash、Silverlight、Flex、およびJavaScriptが含まれる。</dd>
 
     <dt><a id="def-Template" name="def-Template"><dfn>テンプレート (template)</dfn></a></dt>
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>、もしくは<a href="#def-End-Users" title="definition: end user" class="termdef">エンドユーザ</a>のための<a href="#def-Web-Content" title="definition: web content" class="termdef">ウェブコンテンツ</a>を生成する<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>によって記入されているコンテンツの見本（例えば、文書のテンプレート、コンテンツ管理のテンプレート、プレゼンテーションのテーマ）。 多くの場合、テンプレートは、少なくともいくつかのオーサリング上の決定を事前に指定する。
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>、もしくは<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>のための<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を生成する<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>によって記入されているコンテンツの見本（例えば、文書のテンプレート、コンテンツ管理のテンプレート、プレゼンテーションのテーマ）。 多くの場合、テンプレートは、少なくともいくつかのオーサリング上の決定を事前に指定する。
       <ul>
         <li><dfn><a id="def-Accessible-Template" name="def-Accessible-Template">アクセシブルなテンプレート (accessible templates)(WCAG):</a></dfn> 次の両方に該当する場合、<a href="#conf-rel-wcag">WCAG 2.0</a>の達成基準（レベルA、AA又はAAA）を満たすWebコンテンツを作成するよう記入していけるテンプレート：
           <ol type="a">
-            <li>コンテンツ制作者が提供された指示に正しく従う（例えば、<a href="#def-Prompt" title="definition: prompt" class="termdef">プロンプト</a>に正しく応答し、強調表示されたプレースホルダを正しく置き換える）。そして</li>
+            <li>コンテンツ制作者が提供された指示に正しく従う（例えば、<a href="#def-Prompt" title="定義: プロンプト" class="termdef">プロンプト</a>に正しく応答し、強調表示されたプレースホルダを正しく置き換える）。そして</li>
             <li>これ以上のオーサリングは発生しない。</li>
           </ol>
           <em>注記:</em> これらの条件下では、いくつかのテンプレートは完全に空の文書となり、デフォルトでアクセシブルと考えられる。</li>
@@ -1815,20 +1815,20 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 
     <dt><a id="def-Template-Selection-Mechanism" name="def-Template-Selection-Mechanism"><dfn>テンプレート選択機構 (template selection mechanism)</dfn></a></dt>
-    <dd>標準のファイル選択を超え、新たな<a href="#def-Web-Content" title="definition: web content" class="termdef">コンテンツ</a>のための基礎として使用する、もしくは既存のコンテンツに適用する<a href="#def-Template" title="definition: template" class="termdef">テンプレート</a>を選択することを<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に可能にする機能。</dd>
+    <dd>標準のファイル選択を超え、新たな<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>のための基礎として使用する、もしくは既存のコンテンツに適用する<a href="#def-Template" title="定義: テンプレート" class="termdef">テンプレート</a>を選択することを<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に可能にする機能。</dd>
 
     <dt><a name="def-Time-Limit" id="def-Time-Limit"></a><dfn>制限時間 (time limit)</dfn></dt>
-    <dd>タスクを実行する（例えば、メッセージを読み取り、アイテムを選択し、変更を保存する）ため<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>が<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に提供する時間の量。例：オーサリングセッションのタイムアウト、時間間隔でのプレゼンテーション（例えばチュートリアルビデオ）。</dd>
+    <dd>タスクを実行する（例えば、メッセージを読み取り、アイテムを選択し、変更を保存する）ため<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>が<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に提供する時間の量。例：オーサリングセッションのタイムアウト、時間間隔でのプレゼンテーション（例えばチュートリアルビデオ）。</dd>
 
     <dt><a name="def-Tutorial" id="def-Tutorial"></a><dfn>チュートリアル (tutorial)</dfn></dt>
-    <dd>複数の部分からなるタスクを実行する手順を提供する<a href="#def-Documentation" title="definition: documentation" class="termdef">文書</a>のタイプ。</dd>
+    <dd>複数の部分からなるタスクを実行する手順を提供する<a href="#def-Documentation" title="定義: ドキュメンテーション (documentation)" class="termdef">文書</a>のタイプ。</dd>
 
     <dt><a id="def-User-Agent" name="def-User-Agent"><dfn>ユーザエージェント (user agent)</dfn></a> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd><a href="#def-Web-Content" title="definition: web content" class="termdef">ウェブコンテンツ</a>を取得し、レンダリングして<a href="#def-End-Users" title="definition: end user" class="termdef">エンドユーザ</a>との対話を容易にする任意のソフトウェア（例えばウェブブラウザ、ブラウザプラグイン、メディアプレーヤー）
+    <dd><a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">ウェブコンテンツ</a>を取得し、レンダリングして<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>との対話を容易にする任意のソフトウェア（例えばウェブブラウザ、ブラウザプラグイン、メディアプレーヤー）
       <ul>
-        <li><a id="def-Inmarket-User-Agent" name="def-Inmarket-User-Agent"></a><dfn>市場のユーザエージェント (In-Market User Agent):</dfn> 一般人が（無料又はそれ以外で）入手できるユーザエージェント。 通常、市場のユーザエージェントは、<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>とは別のソフトウェアになる。しかし時にソフトウェアは、ユーザエージェントとオーサリングツールの機能を併せ持つこともできる。これらの例は次のとおり：
+        <li><a id="def-Inmarket-User-Agent" name="def-Inmarket-User-Agent"></a><dfn>市場のユーザエージェント (In-Market User Agent):</dfn> 一般人が（無料又はそれ以外で）入手できるユーザエージェント。 通常、市場のユーザエージェントは、<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>とは別のソフトウェアになる。しかし時にソフトウェアは、ユーザエージェントとオーサリングツールの機能を併せ持つこともできる。これらの例は次のとおり：
           <ul>
-            <li><dfn>プレビュー専用 (Preview-Only):</dfn> ユーザエージェントが関連するオーサリング機能から受け取ったウェブコンテンツをレンダリングのみできた場合、そのソフトウェアは<a class="termdef" href="#def-Preview" title="definition: preview">プレビュー</a>機能を備えたオーサリングツールである。このようなプレビューのみの機能は<em>市場のユーザエージェントとはみなされない。</em>.</li>
+            <li><dfn>プレビュー専用 (Preview-Only):</dfn> ユーザエージェントが関連するオーサリング機能から受け取ったウェブコンテンツをレンダリングのみできた場合、そのソフトウェアは<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>機能を備えたオーサリングツールである。このようなプレビューのみの機能は<em>市場のユーザエージェントとはみなされない。</em>.</li>
             <li><a id="def-ua-with-authoring-tool-role" name="def-ua-with-authoring-tool-role"></a><dfn>オーサリングツールモードを持つユーザエージェント (User Agent with Authoring Tool Mode):</dfn> ユーザエージェント機能が、オーサリングツールの機能に送ることができる前にウェブコンテンツを取得し、オープンする必要がある場合、ソフトウェアはオーサリングツールモードを持つユーザエージェントである。ユーザエージェントがオーサリングツールモードによって生成したコンテンツをプレビューするために使用される場合、それは市場のユーザエージェントと見なされるべきである。</li>
             <li><a id="def-comb-ua-authoring-tool" name="def-comb-ua-authoring-tool"></a><dfn>統合ユーザエージェント/オーサリングツール (Combined User Agent/Authoring Tool):</dfn> ユーザとの対話のデフォルトモードでウェブコンテンツの編集を可能にするユーザエージェント。 既に制作者はエンドユーザと同じようにコンテンツを経験しているので、これらのツールでは、プレビューは必要ない。</li>
           </ul>
@@ -1836,34 +1836,34 @@ div.toc ul.toc li ul.toc li ul.toc li a {
       </ul>
     </dd>
     <dt><a id="def-UI-Component" name="def-UI-Component"><dfn>ユーザインタフェース コンポーネント (user interface component)</dfn></a> <!-- [adapted from WCAG 2.0] --></dt>
-    <dd>明確な一つの機能のための単一の制御として<a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>に知覚される、<a href="#def-Authoring-Tool-Interface" title="definition: authoring tool user interface" class="termdef">ユーザインタフェース</a>又は（<a href="#def-Content-Renderings" title="definition: content rendering" class="termdef">コンテンツのレンダリング</a>を含む）コンテンツ表示の一部。 </dd>
+    <dd>明確な一つの機能のための単一の制御として<a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>に知覚される、<a href="#def-Authoring-Tool-Interface" title="定義: オーサリングツールのユーザインタフェース (authoring tool user interface)" class="termdef">ユーザインタフェース</a>又は（<a href="#def-Content-Renderings" title="定義: レンダリングされているコンテンツ (content rendering)" class="termdef">コンテンツのレンダリング</a>を含む）コンテンツ表示の一部。 </dd>
 
     <dt><a name="def-Video" id="def-Video"><dfn>ビデオ (video)</dfn></a> <!-- [adapted from WCAG 2.0] --></dt>
     <dd>写真や動画の技術。ビデオはアニメーション、写真画像、又はその両方で構成することができる。</dd>
     <dt><a id="def-View" name="def-View"><dfn>ビュー (view)</dfn></a></dt>
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="definition: web content being edited">編集中のウェブコンテンツ</a>と対話するために使用するユーザインタフェース機能。 ATAG 2.0は、それらが編集をサポートするかどうかに応じてビューを分類する:
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が<a class="termdef" href="#def-Content-Being-Edited" title="定義: 編集中のコンテンツ (content being edited)">編集中のウェブコンテンツ</a>と対話するために使用するユーザインタフェース機能。 ATAG 2.0は、それらが編集をサポートするかどうかに応じてビューを分類する:
       <ul>
 
         <li><a name="def-Editing-View" id="def-Editing-View"></a><dfn>編集ビュー (editing-views):</dfn> コンテンツの一部又はすべてが編集可能であるビュー。又は </li>
-        <li><a name="def-Preview" id="def-Preview"></a><dfn>プレビュー (previews):</dfn> <a href="#def-Authoring-Action" title="definition: authoring actions" class="termdef">オーサリングアクション</a>が提供されていないビュー（すなわち、ビューは編集できない）。 プレビューは、<a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>で編集されているウェブコンテンツを<a class="termdef" href="#def-User-Agent" title="definition: user agent">ユーザエージェント</a>の<a href="#def-End-Users" title="definition: end user" class="termdef">エンドユーザ</a>に見えるよう提示するために提供されている。 プレビューは、実際の<a class="termdef" href="#def-Inmarket-User-Agent" title="definition: in-market user agent">市場のユーザエージェント</a>を使用して実装することもできるが、無くてはならないものではない。</li>
+        <li><a name="def-Preview" id="def-Preview"></a><dfn>プレビュー (previews):</dfn> <a href="#def-Authoring-Action" title="定義: オーサリングアクション (authoring action)" class="termdef">オーサリングアクション</a>が提供されていないビュー（すなわち、ビューは編集できない）。 プレビューは、<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>で編集されているウェブコンテンツを<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>の<a href="#def-End-Users" title="定義: エンドユーザ (end user)" class="termdef">エンドユーザ</a>に見えるよう提示するために提供されている。 プレビューは、実際の<a class="termdef" href="#def-Inmarket-User-Agent" title="定義: 市場のユーザエージェント">市場のユーザエージェント</a>を使用して実装することもできるが、無くてはならないものではない。</li>
       </ul>
       ATAG 2.0は、コンテンツを提示するビューのアプローチをいくつか認識している:
       <ul>
 
         <li><a name="def-Instruction-Level" id="def-Instruction-Level"></a><dfn>ソースビュー (source views)</dfn><dfn>:</dfn> コンテンツがレンダリングされていない形態で提供されている（例えば、プレーンテキストエディタ）。又は</li>
-        <li><a name="def-Rendered-View" id="def-Rendered-View"></a><dfn>レンダリングされたビュー (rendered views):</dfn> （慣習的な、非慣習的な、又は部分的な）<a href="#def-Content-Renderings" title="definition: content rendering" class="termdef">コンテンツのレンダリング</a>が提示されている。又は</li>
-        <li><a name="def-Meta-Content" id="def-Meta-Content"></a><dfn>属性ビュー (property views):</dfn>コンテンツの属性のみが提示されている。 オーサリングツールは、<a href="#def-Publishing" title="definition: publishing" class="termdef">公開される</a>コンテンツを<a href="#def-Content-Auto-Gen" title="definition: content generation" class="termdef">自動生成する</a>ために、これらの属性を使用する（例えば数字の月と年からカレンダーを生成するCMSカレンダーウィジェット）。</li>
+        <li><a name="def-Rendered-View" id="def-Rendered-View"></a><dfn>レンダリングされたビュー (rendered views):</dfn> （慣習的な、非慣習的な、又は部分的な）<a href="#def-Content-Renderings" title="定義: レンダリングされているコンテンツ (content rendering)" class="termdef">コンテンツのレンダリング</a>が提示されている。又は</li>
+        <li><a name="def-Meta-Content" id="def-Meta-Content"></a><dfn>属性ビュー (property views):</dfn>コンテンツの属性のみが提示されている。 オーサリングツールは、<a href="#def-Publishing" title="定義: 公開" class="termdef">公開される</a>コンテンツを<a href="#def-Content-Auto-Gen" title="定義: コンテンツ生成" class="termdef">自動生成する</a>ために、これらの属性を使用する（例えば数字の月と年からカレンダーを生成するCMSカレンダーウィジェット）。</li>
       </ul>
     </dd>
     <dt><a id="def-Workflow" name="def-Workflow"></a><dfn>ワークフロー (workflow)</dfn></dt>
-    <dd><a href="#def-Author" title="definition: authors" class="termdef">コンテンツ制作者</a>が配信可能な<a href="#def-Web-Content" title="definition: web content" class="termdef">コンテンツ</a>を生成する際に従う通例の手順又はタスク。 <a href="#def-Authoring-Tool" title="definition: authoring tool" class="termdef">オーサリングツール</a>がアプリケーション（例えば、<a href="#def-Markup" title="definition: markup" class="termdef">マークアップ</a>エディタ、画像エディタ、および検証ツール）の集合で構成されている場合、そのワークフローはアプリケーションの1つ又は複数の使用を含むことができる。 </dd>
+    <dd><a href="#def-Author" title="定義: コンテンツ制作者 (authors)"" class="termdef">コンテンツ制作者</a>が配信可能な<a href="#def-Web-Content" title="定義: コンテンツ (ウェブコンテンツ) (content (web content))" class="termdef">コンテンツ</a>を生成する際に従う通例の手順又はタスク。 <a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>がアプリケーション（例えば、<a href="#def-Markup" title="定義: マークアップ" class="termdef">マークアップ</a>エディタ、画像エディタ、および検証ツール）の集合で構成されている場合、そのワークフローはアプリケーションの1つ又は複数の使用を含むことができる。 </dd>
   </dl>
   <hr />
 </div> <!-- sect-definitions -->
 <div id="sect-references">
   <h2><a id="references" name="references"></a>付録<span class="gl-only">B</span>: 参考文献</h2>
   <p><acronym title="the World Wide Web Consortium">W3C</acronym>標準の<strong>最新版</strong>は、http://www.w3.org/TR/ の<a href="http://www.w3.org/TR/">W3C Technical Reports</a>の一覧を参照して下さい。この文書の公開以降、以下に示すいくつかの文書が差し替えられている可能性があります。</p>
-  <p>この節は、<a href="#def-Normative" title="definition: normative" class="termdef">規定</a>である。</p>
+  <p>この節は、<a href="#def-Normative" title="定義: 規定 (normative)" class="termdef">規定</a>である。</p>
   <dl>
 
 
@@ -1874,7 +1874,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
     <dd>&quot;<a href="http://www.w3.org/TR/2008/REC-WCAG20-20081211/">Web Content Accessibility Guidelines 2.0 </a>&quot;, B. Caldwell, M. Cooper, L. Guarino Reid, and G. Vanderheiden, eds. 11 December 2008.</dd>
   </dl>
-  <p>この節は、<a href="#def-Informative" title="definition: informative" class="termdef">参考情報</a>である。</p>
+  <p>この節は、<a href="#def-Informative" title="定義: 参考情報 (informative)" class="termdef">参考情報</a>である。</p>
   <dl><dt><a name="ref-ATAG10" id="ref-ATAG10">[ATAG10]</a></dt>
     <dd>&quot;<a href="http://www.w3.org/TR/2000/REC-ATAG10-20000203/">Authoring Tool Accessibility Guidelines 1.0</a>&quot;, J. Treviranus, C. McCathieNevile, I. Jacobs, and J. Richards, eds., 3 February 2000.</dd>
 


### PR DESCRIPTION
issue #99 に記載の `sed` スクリプトで、 `title` 属性の訳出を行いました。
レビューをお願いいたします。