### PR TITLE
A.2.1.2(b) 翻訳の見直し #117

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -476,7 +476,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 	  <h4 class="sc-title"><a id="sc_a212" name="sc_a212"></a>A.2.1.2 レンダリングされた時間依存メディアの代替コンテンツ: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が時間依存メディアを<a class="termdef" href="#def-Content-Renderings" title="定義: コンテンツレンダリング">レンダリング</a>する場合、次に挙げる事項のうち、少なくとも一つを満たしている。<span class="level">（<strong>レベル A</strong>）</span></p>
 	  <ul class="sc-bullets">
       <li class="sc-bullet"><strong class="handle">(a) レンダリングのオプション:</strong> <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>は時間依存メディアの代替コンテンツをレンダリングする<a href="#def-Option" title="定義: オプション" class="termdef">オプション</a>を提供する。または、</li>
-	  <li class="sc-bullet"><strong class="handle">(b) ユーザエージェントのオプション:</strong> <a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>のオプションによって、時間依存メディアの代替コンテンツを<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>することができる。</li>
+	  <li class="sc-bullet"><strong class="handle">(b) ユーザエージェントのオプション:</strong> <a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は代替コンテンツをレンダリング可能な<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>上で、時間依存メディアを<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>するためのオプションを持つ。</li>
 	  </ul>
 
 	   <div class="gl-only">

--- a/docs/index.html
+++ b/docs/index.html
@@ -475,7 +475,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 	  <h4 class="sc-title"><a id="sc_a212" name="sc_a212"></a>A.2.1.2 レンダリングされた時間依存メディアの代替コンテンツ: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が時間依存メディアを<a class="termdef" href="#def-Content-Renderings" title="定義: コンテンツレンダリング">レンダリング</a>する場合、次に挙げる事項のうち、少なくとも一つを満たしている。<span class="level">（<strong>レベル A</strong>）</span></p>
 	  <ul class="sc-bullets">
-      <li class="sc-bullet"><strong class="handle">(a) レンダリングのオプション:</strong> <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>は時間依存メディアの代替コンテンツをレンダリングする<a href="#def-Option" title="定義: オプション" class="termdef">オプション</a>を提供する。または、</li>
+      <li class="sc-bullet"><strong class="handle">(a) レンダリングするオプション:</strong> <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>は時間依存メディアの代替コンテンツをレンダリングする<a href="#def-Option" title="定義: オプション" class="termdef">オプション</a>を提供する。または、</li>
 	  <li class="sc-bullet"><strong class="handle">(b) ユーザエージェントのオプション:</strong> <a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は代替コンテンツをレンダリング可能な<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>上で、時間依存メディアを<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>するためのオプションを持つ。</li>
 	  </ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -475,7 +475,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 	  <h4 class="sc-title"><a id="sc_a212" name="sc_a212"></a>A.2.1.2 レンダリングされた時間依存メディアの代替コンテンツ: </h4><p class="sc-title"><a class="termdef" href="#def-Editing-View" title="定義: 編集ビュー">編集ビュー</a>が時間依存メディアを<a class="termdef" href="#def-Content-Renderings" title="定義: コンテンツレンダリング">レンダリング</a>する場合、次に挙げる事項のうち、少なくとも一つを満たしている。<span class="level">（<strong>レベル A</strong>）</span></p>
 	  <ul class="sc-bullets">
-      <li class="sc-bullet"><strong class="handle">(a) レンダリングするオプション:</strong> <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>は時間依存メディアの代替コンテンツをレンダリングする<a href="#def-Option" title="定義: オプション" class="termdef">オプション</a>を提供する。または、</li>
+      <li class="sc-bullet"><strong class="handle">(a) レンダリングするオプション:</strong> <a class="termdef" href="#def-Authoring-Tool" title="定義: オーサリングツール">オーサリングツール</a>は時間依存メディアの代替コンテンツをレンダリングする<a href="#def-Option" title="定義: オプション" class="termdef">オプション</a>を提供する。又は、</li>
 	  <li class="sc-bullet"><strong class="handle">(b) ユーザエージェントのオプション:</strong> <a class="termdef" href="#def-Author" title="定義: コンテンツ制作者">コンテンツ制作者</a>は代替コンテンツをレンダリング可能な<a class="termdef" href="#def-User-Agent" title="定義: ユーザエージェント">ユーザエージェント</a>上で、時間依存メディアを<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>するためのオプションを持つ。</li>
 	  </ul>
 


### PR DESCRIPTION
Close #117

# プルリクエスト作成時の確認事項

- [x] 翻訳ガイドラインを確認し、ガイドラインに沿っているかチェックした
- [x] WCAGの用語集を確認し、用語が揃っているかチェックした
- [x] WG4の用語集を確認し、用語が揃っているかチェックした

# コメント

もんどさんとばけらさんご指摘いただいた箇所に関して修正をするとともに（b）の全体も見直しをしました。
（b）の意図は、[Implementing A.2.1.2](https://www.w3.org/TR/2015/NOTE-IMPLEMENTING-ATAG20-20150924/#sc_a212) を読んだところ、
単に「ユーザエージェントの機能により代替コンテンツがプレビューできる」のではなく、
「代替コンテンツがレンダリングできるユーザエージェント上で（例えば移動するなどして）プレビューができる」だと思いましたので、
誤解のないように原文に沿う形で言い回しを修正しました。

