### PR TITLE
お問い合わせリンクをGoogle Formへ変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 <body>
 
 <aside class="trnote">
-<p>この文書は、<a href="https://www.w3.org/TR/2015/REC-ATAG20-20150924/">2015 年 9 月 24 日付けのW3C 勧告 Authoring Tool Accessibility Guidelines (ATAG) 2.0</a>について、<a href="https://github.com/fukumotoy/atag20-ja">fukumotoy氏</a>が翻訳されたものを、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>が引き継いで翻訳し、公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/">翻訳に関するお問い合わせ</a>からご連絡ください。</p>
+<p>この文書は、<a href="https://www.w3.org/TR/2015/REC-ATAG20-20150924/">2015 年 9 月 24 日付けのW3C 勧告 Authoring Tool Accessibility Guidelines (ATAG) 2.0</a>について、<a href="https://github.com/fukumotoy/atag20-ja">fukumotoy氏</a>が翻訳されたものを、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>が引き継いで翻訳し、公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/" id="file-issue">翻訳に関するお問い合わせ</a>からご連絡ください。</p>
 </aside>
 
 <div class="head">
@@ -1927,6 +1927,6 @@ div.toc ul.toc li ul.toc li ul.toc li a {
 
 </div>
  <!-- techs-only -->
-
+<script src="https://waic.jp/docs/js/translation-contact.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Close #120 

https://github.com/waic/wcag20/pull/336 を参考にスクリプトを追加しました。  
リンク遷移後、フォームにページURLが自動的に入っていることを確認済みです。