### PR TITLE
「プレビュー専用」の見直し

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1811,7 +1811,7 @@ div.toc ul.toc li ul.toc li ul.toc li a {
         <li><a id="def-Inmarket-User-Agent" name="def-Inmarket-User-Agent"></a><dfn>市場のユーザエージェント (In-Market User Agent):</dfn> 一般人が (無料又はそれ以外で) 入手できるユーザエージェント。通常、市場のユーザエージェントは、<a href="#def-Authoring-Tool" title="オーサリングツール (authoring tool)" class="termdef">オーサリングツール</a>とは別のソフトウェアになる。しかし時にソフトウェアは、ユーザエージェントとオーサリングツールの機能を併せ持つこともできる。これらの例は次のとおり:
           <ul>
             <li><dfn>プレビュー専用 (Preview-Only):</dfn> ユーザエージェントが関連するオーサリング機能から受け取ったウェブコンテンツをレンダリングのみできた場合、そのソフトウェアは<a class="termdef" href="#def-Preview" title="定義: プレビュー">プレビュー</a>機能を備えたオーサリングツールである。このようなプレビューのみの機能は<em>市場のユーザエージェントとはみなされない。</em></li>
-            <li><a id="def-ua-with-authoring-tool-role" name="def-ua-with-authoring-tool-role"></a><dfn>オーサリングツールモードを持つユーザエージェント (User Agent with Authoring Tool Mode):</dfn> ユーザエージェント機能が、オーサリングツールの機能に送ることができる前にウェブコンテンツを取得し、オープンする必要がある場合、ソフトウェアはオーサリングツールモードを持つユーザエージェントである。ユーザエージェントがオーサリングツールモードによって生成したコンテンツをプレビューするために使用される場合、それは市場のユーザエージェントと見なされるべきである。</li>
+            <li><a id="def-ua-with-authoring-tool-role" name="def-ua-with-authoring-tool-role"></a><dfn>オーサリングツールモードを持つユーザエージェント (User Agent with Authoring Tool Mode):</dfn> ユーザエージェント機能が、オーサリングツールの機能に送ることができる前に、ウェブコンテンツを取得して開かなければならない場合、そのソフトウェアはオーサリングツールモードを持つユーザエージェントである。ユーザエージェントがオーサリングツールモードによって生成したコンテンツをプレビューするために使用される場合、それは市場のユーザエージェントであると見なされる。</li>
             <li><a id="def-comb-ua-authoring-tool" name="def-comb-ua-authoring-tool"></a><dfn>統合ユーザエージェント／オーサリングツール (Combined User Agent/Authoring Tool):</dfn> ユーザとの対話のデフォルトモードでウェブコンテンツの編集を可能にするユーザエージェント。既に制作者はエンドユーザと同じようにコンテンツを経験しているので、これらのツールでは、プレビューは必要ない。</li>
           </ul>
         </li>


### PR DESCRIPTION
Issue #111 対応として、文面を修正しました。

// 実際は、「プレビュー専用 (Preview-Only)」ではなくその直下の「オーサリングツールモードを持つユーザエージェント (User Agent with Authoring Tool Mode)」ですね。

> 「プレビュー専用」の訳が微妙に変。
> 

> > If the user agent functionality must retrieve and open web content before it can be sent to the authoring tool functionality, then the software is a user agent with an authoring tool mode. If the user agent is used to preview content produced by the authoring tool mode, then it is to be considered an in-market user agent.

> 
> 少なくとも、
> 
> オープンする必要がある←must retrieve and openなので、「～しなければならない」とするべき
> 市場のユーザエージェントと見なされるべきである。← it is to be consideredなので、こう取っても誤りではないのですが、shouldではないのでかぶってしまうのが懸念事項
> といったところ。

